### PR TITLE
Avoid high cost crayon functions

### DIFF
--- a/R/sigfig.R
+++ b/R/sigfig.R
@@ -163,7 +163,7 @@ format_lhs <- function(s) {
 
 underline_3_back <- function(x) {
   idx <- which(trunc((seq_along(x) - length(x)) / 3) %% 2 == 1)
-  x[idx] <- crayon::underline(x[idx])
+  x[idx] <- underline(x[idx])
   x
 }
 
@@ -228,7 +228,7 @@ format_rhs <- function(s) {
 
 underline_3 <- function(x) {
   idx <- which(trunc((seq_along(x) - 1) / 3) %% 2 == 1)
-  x[idx] <- crayon::underline(x[idx])
+  x[idx] <- underline(x[idx])
   x
 }
 

--- a/R/styles.R
+++ b/R/styles.R
@@ -54,7 +54,7 @@ style_hint <- keep_empty(function(x) {
 })
 
 style_spark_na <- function(x) {
-  crayon::yellow(x)
+  yellow(x)
 }
 
 #' @details
@@ -66,7 +66,7 @@ style_spark_na <- function(x) {
 #' style_bold("Petal.Width")
 style_bold <- function(x) {
   if (isTRUE(getOption("pillar.bold", FALSE))) {
-    crayon::bold(x)
+    bold(x)
   } else {
     x
   }
@@ -77,7 +77,7 @@ style_bold <- function(x) {
 #' @examples
 #' style_na("NA")
 style_na <- function(x) {
-  crayon::red(x)
+  red(x)
 }
 
 #' @details
@@ -89,18 +89,17 @@ style_na <- function(x) {
 #' style_neg("123")
 style_neg <- keep_empty(function(x) {
   if (isTRUE(getOption("pillar.neg", TRUE))) {
-    crayon::red(x)
+    red(x)
   } else {
     x
   }
 })
 
 make_style_grey <- function(level) {
-  style <- crayon::make_style(grDevices::grey(level), grey = TRUE)
+  style <- make_fast_style(grDevices::grey(level), grey = TRUE)
 
   function(...) {
-    x <- paste0(...)
-    crayon::style(x, style)
+    style(...)
   }
 }
 
@@ -113,7 +112,7 @@ assign_style_grey <- function() {
 }
 
 pillar_na <- function(use_brackets_if_no_color = FALSE) {
-  if (use_brackets_if_no_color && !crayon::has_color()) {
+  if (use_brackets_if_no_color && !has_color()) {
     "<NA>"
   } else {
     style_na("NA")

--- a/R/styles.R
+++ b/R/styles.R
@@ -95,20 +95,12 @@ style_neg <- keep_empty(function(x) {
   }
 })
 
-make_style_grey <- function(level) {
-  style <- make_fast_style(grDevices::grey(level), grey = TRUE)
-
-  function(...) {
-    style(...)
-  }
-}
-
 # Placeholders, assigned in .onLoad()
 style_grey <- new.env(parent = emptyenv())
 
 assign_style_grey <- function() {
-  style_grey$"0.6" <- make_style_grey(0.6)
-  style_grey$"0.8" <- make_style_grey(0.8)
+  style_grey$"0.6" <- make_style_fast(grDevices::grey(0.6), grey = TRUE)
+  style_grey$"0.8" <- make_style_fast(grDevices::grey(0.8), grey = TRUE)
 }
 
 pillar_na <- function(use_brackets_if_no_color = FALSE) {

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -37,14 +37,18 @@ expect_known_display <- function(object, file, ..., width = 80L, crayon = TRUE) 
 
   if (crayon) {
     old <- options(crayon.enabled = TRUE, crayon.colors = 16L, width = width)
+    has_color(forget = TRUE)
     crayon::num_colors(forget = TRUE)
     assign_style_grey()
   } else {
     old <- options(crayon.enabled = FALSE, width = width)
+    has_color(forget = TRUE)
+    crayon::num_colors(forget = TRUE)
   }
 
   on.exit({
     options(old)
+    has_color(forget = TRUE)
     crayon::num_colors(forget = TRUE)
     assign_style_grey()
   })

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -44,6 +44,7 @@ expect_known_display <- function(object, file, ..., width = 80L, crayon = TRUE) 
     old <- options(crayon.enabled = FALSE, width = width)
     has_color(forget = TRUE)
     crayon::num_colors(forget = TRUE)
+    assign_style_grey()
   }
 
   on.exit({

--- a/R/type.R
+++ b/R/type.R
@@ -3,7 +3,7 @@ MIN_PILLAR_WIDTH <- 5L
 style_type <- function(x) {
   force(x)
   x <- style_subtle(x)
-  crayon::italic(x)
+  italic(x)
 }
 
 #' Prepare a column type for formatting

--- a/R/utils.R
+++ b/R/utils.R
@@ -50,3 +50,37 @@ remove_as_is_class <- function(x) {
 diff_to_trunc <- function(x) {
   x - trunc(x)
 }
+
+# Only check if we have color support once per session
+has_color <- local({
+  has_color <- NULL
+  function(forget = FALSE) {
+    if (is.null(has_color) || forget) {
+      has_color <<- crayon::has_color()
+    }
+    has_color
+  }
+})
+
+# Crayon functions call crayon::has_color() every call
+make_fast_style <- function(...) {
+  style <- crayon::make_style(...)
+  styles <- attr(style, "_styles")[[1]]
+  open <- styles$open
+  close <- styles$close
+  function(...) {
+    if (has_color()) {
+      paste0(open, ..., close)
+    } else {
+      paste0(...)
+    }
+  }
+}
+
+underline <- make_fast_style("underline")
+
+italic <- make_fast_style("italic")
+
+red <- make_fast_style("red")
+yellow <- make_fast_style("yellow")
+bold <- make_fast_style("bold")

--- a/R/utils.R
+++ b/R/utils.R
@@ -63,10 +63,15 @@ has_color <- local({
 })
 
 # Crayon functions call crayon::has_color() every call
-make_fast_style <- function(...) {
+make_style_fast <- function(...) {
+  # Force has_color to be true when making styles
+  old <- options(crayon.enabled = TRUE)
+  on.exit(options(old))
+
   style <- crayon::make_style(...)
   start <- stats::start(style)
   finish <- crayon::finish(style)
+
   function(...) {
     if (has_color()) {
       paste0(start, ..., finish)
@@ -76,10 +81,8 @@ make_fast_style <- function(...) {
   }
 }
 
-underline <- make_fast_style("underline")
-
-italic <- make_fast_style("italic")
-
-red <- make_fast_style("red")
-yellow <- make_fast_style("yellow")
-bold <- make_fast_style("bold")
+underline <- make_style_fast("underline")
+italic <- make_style_fast("italic")
+red <- make_style_fast("red")
+yellow <- make_style_fast("yellow")
+bold <- make_style_fast("bold")

--- a/R/utils.R
+++ b/R/utils.R
@@ -65,12 +65,11 @@ has_color <- local({
 # Crayon functions call crayon::has_color() every call
 make_fast_style <- function(...) {
   style <- crayon::make_style(...)
-  styles <- attr(style, "_styles")[[1]]
-  open <- styles$open
-  close <- styles$close
+  start <- stats::start(style)
+  finish <- crayon::finish(style)
   function(...) {
     if (has_color()) {
-      paste0(open, ..., close)
+      paste0(start, ..., finish)
     } else {
       paste0(...)
     }


### PR DESCRIPTION
The crayon style functions call `has_color()` on every call, which has a
relatively high cost when it is repeated many times; unless the
crayon.enabled option is set. They also use some internal functions e.g.
`%+%` which are fairly costly if there are many calls.

This avoids these costs by

1. caching the result of `has_color()` for the
   entire session. (It can be recomputed by calling `has_color(forget = TRUE)`)

2. Simply using `paste0()` to combine the open and closing escapes with
   the content. This is not as flexible as the crayon implementation,
   but works for the use cases in pillar.

The following benchmark shows these changes result in an order of
magnitude improvement in execution time for the mtcars dataset.

```r
mtcarst <- tibble::as_tibble(mtcars)
r <- git2r::repository()
git2r::checkout(r, "master")
pkgload::load_all()

bnch <- bench::mark(
  base = as.matrix(format.data.frame(mtcars)),
  old = format(mtcarst),
  check = FALSE, min_iterations = 10, filter_gc = FALSE
)

git2r::checkout(r, "fast-style")
pkgload::load_all()

bnch <- rbind(bnch,
  bench::mark(new = format(mtcarst), filter_gc = FALSE, min_iterations = 10)
)

bnch
summary(bnch, relative = TRUE, filter_gc = FALSE)

bnch
#> # A tibble: 3 x 14
#>   expression      min     mean   median      max `itr/sec` mem_alloc  n_gc n_itr total_time
#>   <chr>      <bch:tm> <bch:tm> <bch:tm> <bch:tm>     <dbl> <bch:byt> <dbl> <int>   <bch:tm>
#> 1 base         1.09ms   1.29ms   1.18ms   8.82ms    773.      9.92KB     4   387   500.39ms
#> 2 old        673.58ms 698.03ms 699.43ms 721.19ms      1.43   14.94MB    53    10      6.98s
#> 3 new         72.98ms  80.54ms  78.56ms  92.24ms     12.4    245.6KB     7    10   805.39ms

summary(bnch, relative = TRUE, filter_gc = FALSE)
#> # A tibble: 3 x 14
#>   expression   min  mean median   max `itr/sec` mem_alloc  n_gc n_itr total_time
#>   <chr>      <dbl> <dbl>  <dbl> <dbl>     <dbl>     <dbl> <dbl> <dbl>      <dbl>
#> 1 base         1     1      1     1      540.         1    1     38.7       1   
#> 2 old        617.  540.   593.   81.7      1       1542.  13.2    1        13.9 
#> 3 new         66.8  62.3   66.6  10.5      8.67      24.8  1.75   1         1.61
```