### PR TITLE
Update base type abbrevs to rlang 0.3.0

### DIFF
--- a/R/type-sum.R
+++ b/R/type-sum.R
@@ -33,8 +33,16 @@ type_sum.default <- function(x) {
       double = "dbl",
       character = "chr",
       complex = "cpl",
+      builtin = ,
+      special = ,
       closure = "fn",
       environment = "env",
+      symbol =
+        if (is_missing(x)) {
+          "missing"
+        } else {
+          "sym"
+        },
       typeof(x)
     )
   } else if (!isS4(x)) {

--- a/tests/testthat/test-obj-sum.R
+++ b/tests/testthat/test-obj-sum.R
@@ -37,5 +37,8 @@ test_that("difftime is shown as time", {
 test_that("less common objects get abbreviations", {
   expect_equal(type_sum(environment()), "env")
   expect_equal(type_sum(environment), "fn")
+  expect_equal(type_sum(list), "fn")
   expect_equal(type_sum(1i), "cpl")
+  expect_equal(type_sum(quote(foo)), "sym")
+  expect_equal(type_sum(expr()), "missing")
 })


### PR DESCRIPTION
Handle symbols, the missing argument, and primitive functions.