### PR TITLE
Resolve `vec_is()` dynamically

### DIFF
--- a/R/type-sum.R
+++ b/R/type-sum.R
@@ -58,7 +58,9 @@ type_sum.default <- function(x) {
 
 # vec_is() needs vctrs > 0.1.0
 # Defined in .onLoad()
-vec_is <- NULL
+vec_is <- function(...) {
+  vctrs::vec_is(...)
+}
 
 compat_vec_is <- function(x) {
   is_vector(x)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -19,12 +19,7 @@ NULL
     rm("strrep", inherits = TRUE)
   }
 
-  if (utils::packageVersion("vctrs") > "0.1.0") {
-    vec_is <<- function(...) {
-      vec_is <- get("vec_is", asNamespace("vctrs"))
-      vec_is(...)
-    }
-  } else {
+  if (utils::packageVersion("vctrs") <= "0.1.0") {
     vec_is <<- compat_vec_is
   }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -20,7 +20,10 @@ NULL
   }
 
   if (utils::packageVersion("vctrs") > "0.1.0") {
-    vec_is <<- get("vec_is", asNamespace("vctrs"))
+    vec_is <<- function(...) {
+      vec_is <- get("vec_is", asNamespace("vctrs"))
+      vec_is(...)
+    }
   } else {
     vec_is <<- compat_vec_is
   }


### PR DESCRIPTION
cc https://github.com/r-lib/vctrs/pull/314

This is a stopgap but I suggest removing the dependency on vctrs for now.