### PR TITLE
Adding support for minimum character width

### DIFF
--- a/R/pillar-package.R
+++ b/R/pillar-package.R
@@ -26,6 +26,10 @@
 #'     title, default: `15`.  Column titles may be truncated up to that width to
 #'     save horizontal space. Set to `Inf` to turn off truncation of column
 #'     titles.
+#' - `pillar.min_character_chars`: The minimum number of characters wide to
+#'     display character columns, default: `0`.  Character columns may be
+#'     truncated up to that width to save horizontal space. Set to `Inf` to
+#'     turn off truncation of column titles.
 #'
 #' @examples
 #' pillar(1:3)

--- a/R/shaft.R
+++ b/R/shaft.R
@@ -184,6 +184,13 @@ pillar_shaft.character <- function(x, ..., min_width = 3L) {
     na_indent <- 0
   }
 
+  # determine width based on width of characters in the vector
+  character_chars <- getOption("pillar.min_character_chars", 0)
+  if (!is.numeric(character_chars) || length(character_chars) != 1 || character_chars < 0) {
+    stop("Option pillar.min_character_chars must be a nonnegative number", call. = FALSE)
+  }
+  min_width <- max(min_width, min(character_chars, get_max_extent(x)))
+
   pillar_shaft(new_vertical(out), ..., min_width = min_width, na_indent = na_indent)
 }
 

--- a/man/pillar-package.Rd
+++ b/man/pillar-package.Rd
@@ -31,6 +31,10 @@ turn off highlighting of significant digits.
 title, default: \code{15}.  Column titles may be truncated up to that width to
 save horizontal space. Set to \code{Inf} to turn off truncation of column
 titles.
+\item \code{pillar.min_character_chars}: The minimum number of characters wide to
+display character columns, default: \code{0}.  Character columns may be
+truncated up to that width to save horizontal space. Set to \code{Inf} to
+turn off truncation of column titles.
 }
 }
 


### PR DESCRIPTION
Addresses #101 by implementing an option pillar.min_character_chars to give control over how wide to make characters for a character column. The option works similarly to pillar.min_title_chars. The default is currently 0 to be backwards compatible.

Like others, I needed this for a project I am working on (a bookdown book that needs users to see the full names of a kibble's character column) and was frustrated trying to get it to work. If there is a better approach to this, happy to adjust.