### PR TITLE
Support readable line breaks

### DIFF
--- a/R/shaft-.R
+++ b/R/shaft-.R
@@ -214,6 +214,9 @@ pillar_shaft.character <- function(x, ..., min_width = NULL) {
       options(pillar.min_chars = min_width)
     }
   }
+  
+  # do not print line breaks, but instead format them in a readable way
+  out <- gsub("\n", style_na("\\n"), out, fixed = TRUE)
 
   pillar_shaft(new_vertical(out), ..., min_width = min_width, na_indent = na_indent)
 }


### PR DESCRIPTION
This PR makes it possible to still read line breaks in characters, which is otherwise quite annoying if you're creating e.g. plot labels with line breaks.

```r
df <- tibble(a = "test text without break", 
             b = "test text\nwith break", 
             c = "test text without break")
df
#> # A tibble: 1 x 3
#>   a                       b                    c                      
#>   <chr>                   <chr>                <chr>                  
#> 1 test text without break test text
#> with break test text without break
```

to:

```r
#> # A tibble: 1 x 3
#>   a                       b                     c                      
#>   <chr>                   <chr>                 <chr>                  
#> 1 test text without break test text\nwith break test text without break
```

The `\n` prints as the colour given in `style_na()`:
![image](https://user-images.githubusercontent.com/31037261/96848025-2c6bc200-1454-11eb-9261-fef86ddd4c03.png)
