### PR TITLE
Faster align()

### DIFF
--- a/R/extent.R
+++ b/R/extent.R
@@ -49,9 +49,17 @@ align <- function(x, width = NULL, align = c("left", "right")) {
     width <- max(extent)
   }
   spaces <- pmax(width - extent, 0L)
-  if (align == "left") {
-    paste0(x, strrep(" ", spaces))
-  } else {
-    paste0(strrep(" ", spaces), x)
+
+  pad <- which(spaces > 0)
+  if (length(pad) == 0) {
+    return(x)
   }
+
+  if (align == "left") {
+    x[pad] <- paste0(x[pad], strrep(" ", spaces[pad]))
+  } else {
+    x[pad] <- paste0(strrep(" ", spaces[pad]), x[pad])
+  }
+
+  x
 }


### PR DESCRIPTION
if input is already aligned.

## Before

``` r
library(pillar)

bench::mark(align(letters, 1))
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 align(letters, 1)   48.8µs   55.2µs    15416.     233KB     42.9
bench::mark(align(c("a", "ab", "abc", "abcd", "abcde"), 5))
#> # A tibble: 1 x 6
#>   expression                                        min median `itr/sec`
#>   <bch:expr>                                     <bch:> <bch:>     <dbl>
#> 1 align(c("a", "ab", "abc", "abcd", "abcde"), 5) 43.8µs 47.6µs    18716.
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>
```

<sup>Created on 2020-11-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

## After

``` r
library(pillar)

bench::mark(align(letters, 1))
#> # A tibble: 1 x 6
#>   expression             min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 align(letters, 1)     41µs   46.9µs    19093.     242KB     51.2
bench::mark(align(c("a", "ab", "abc", "abcd", "abcde"), 5))
#> # A tibble: 1 x 6
#>   expression                                        min median `itr/sec`
#>   <bch:expr>                                     <bch:> <bch:>     <dbl>
#> 1 align(c("a", "ab", "abc", "abcd", "abcde"), 5) 45.6µs 50.7µs    18007.
#> # … with 2 more variables: mem_alloc <bch:byt>, `gc/sec` <dbl>
```

<sup>Created on 2020-11-21 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>