### PR TITLE
unknown_rows no longer inherits from data.frame

### DIFF
--- a/tests/testthat/helper-unknown-rows.R
+++ b/tests/testthat/helper-unknown-rows.R
@@ -1,17 +1,22 @@
 as_unknown_rows <- function(x) {
   x <- as_tbl(x)
-  class(x) <- c("unknown_rows", class(x))
+  class(x) <- c("unknown_rows", "tbl")
   x
 }
 
 local_unknown_rows <- function(frame = caller_env()) {
   local_methods(
     .frame = frame,
+    as.data.frame.unknown_rows = function(x, ...) {
+      class(x) <- "data.frame"
+      x
+    },
     dim.unknown_rows = function(x) {
       c(NA_integer_, length(x))
     },
     head.unknown_rows = function(x, n) {
-      head(as.data.frame(x), n)
+      class(x) <- "data.frame"
+      head(x, n)
     }
   )
 }


### PR DESCRIPTION
to better approximate dbplyr tbl objects.