### PR TITLE
Use excess horizontal space

### DIFF
--- a/R/ctl_colonnade.R
+++ b/R/ctl_colonnade.R
@@ -65,7 +65,7 @@ pillar_format_tier <- function(pillars, widths, max_widths) {
   extra <- sum(widths - extents)
 
   # Second pass: trying to use the remaining width, starting at the left
-  col_idx <- 1
+  col_idx <- 1L
   while (extra > 0 && col_idx <= length(pillars)) {
     new_formatted <- pillar_format_parts_2(pillars[[col_idx]], min(widths[[col_idx]] + extra, max_widths[[col_idx]]))
     delta <- new_formatted$max_extent - formatted[[col_idx]]$max_extent

--- a/R/ctl_colonnade.R
+++ b/R/ctl_colonnade.R
@@ -39,8 +39,14 @@ ctl_colonnade <- function(x, has_row_id = TRUE, width = NULL, controller = new_t
   tiers <- split(seq_len(nrow(col_widths)), col_widths$tier)
 
   flat_tiers <- map(tiers, function(tier) {
-    formatted <- col_widths$formatted[tier]
-    map(formatted, function(.x) .x$aligned[[1]])
+    formatted <- map2(
+      col_widths$pillar[tier], col_widths$width[tier],
+      pillar_format_parts_2
+    )
+
+    map(formatted, function(.x) {
+      .x$aligned[[1]]
+    })
   })
 
   if (!is.null(rowid)) {

--- a/R/ctl_colonnade.R
+++ b/R/ctl_colonnade.R
@@ -60,18 +60,19 @@ pillar_format_tier <- function(pillars, widths, max_widths) {
   extra <- sum(widths - extents)
 
   # Second pass: trying to use the remaining width, starting at the left
-  for (col_idx in which(widths < max_widths)) {
-    if (extra <= 0) {
-      break
+  if (extra > 0) {
+    for (col_idx in which(widths < max_widths)) {
+      new_formatted <- pillar_format_parts_2(pillars[[col_idx]], min(widths[[col_idx]] + extra, max_widths[[col_idx]]))
+      delta <- new_formatted$max_extent - formatted[[col_idx]]$max_extent
+      if (delta > 0) {
+        formatted[[col_idx]] <- new_formatted
+        extra <- extra - delta
+        if (extra <= 0) {
+          break
+        }
+      }
+      col_idx <- col_idx + 1L
     }
-
-    new_formatted <- pillar_format_parts_2(pillars[[col_idx]], min(widths[[col_idx]] + extra, max_widths[[col_idx]]))
-    delta <- new_formatted$max_extent - formatted[[col_idx]]$max_extent
-    if (delta > 0) {
-      extra <- extra - delta
-      formatted[[col_idx]] <- new_formatted
-    }
-    col_idx <- col_idx + 1L
   }
 
   map(formatted, function(.x) {

--- a/R/ctl_colonnade.R
+++ b/R/ctl_colonnade.R
@@ -65,8 +65,11 @@ pillar_format_tier <- function(pillars, widths, max_widths) {
   extra <- sum(widths - extents)
 
   # Second pass: trying to use the remaining width, starting at the left
-  col_idx <- 1L
-  while (extra > 0 && col_idx <= length(pillars)) {
+  for (col_idx in which(widths < max_widths)) {
+    if (extra <= 0) {
+      break
+    }
+
     new_formatted <- pillar_format_parts_2(pillars[[col_idx]], min(widths[[col_idx]] + extra, max_widths[[col_idx]]))
     delta <- new_formatted$max_extent - formatted[[col_idx]]$max_extent
     if (delta > 0) {

--- a/R/ctl_colonnade.R
+++ b/R/ctl_colonnade.R
@@ -31,11 +31,6 @@ ctl_colonnade <- function(x, has_row_id = TRUE, width = NULL, controller = new_t
   compound_pillar <- combine_pillars(pillars)
   col_widths <- colonnade_get_width_2(compound_pillar, tier_widths)
 
-  col_widths$formatted <- map2(
-    col_widths$pillar, col_widths$width,
-    pillar_format_parts_2
-  )
-
   tiers <- split(seq_len(nrow(col_widths)), col_widths$tier)
 
   flat_tiers <- map(tiers, function(tier) {

--- a/tests/testthat/_snaps/ctl_colonnade.md
+++ b/tests/testthat/_snaps/ctl_colonnade.md
@@ -807,3 +807,21 @@
       named list()
       
 
+# filling unused width (#331)
+
+    Code
+      data
+    Output
+      # A data frame: 1 x 3
+        month   sentences                                           blah              
+        <chr>   <foo>                                               <chr>             
+      1 January a b c d e f g h i j k l m n o p q r s t u v w x y z A B C D E F G H I~
+    Code
+      options(width = 60)
+      print(data)
+    Output
+      # A data frame: 1 x 3
+        month   sentences blah                                    
+        <chr>   <foo>     <chr>                                   
+      1 January a b c d~  A B C D E F G H I J K L M N O P Q R S T~
+


### PR DESCRIPTION
If a column doesn't make use of the width offered to it, the excess width is offered to subsequent columns.

This requires two passes over all columns that don't use their full width.

Closes #331.