### PR TITLE
Document default obj_sum() method

### DIFF
--- a/R/type-sum.R
+++ b/R/type-sum.R
@@ -64,11 +64,12 @@ vec_ptype_abbr.pillar_empty_col <- function(x, ...) {
 }
 
 #' @description
-#' `obj_sum()` also includes the size of the object if [vctrs::vec_is()]
-#' is `TRUE`.
+#' `obj_sum()` also includes the size (but not the shape) of the object
+#' if [vctrs::vec_is()] is `TRUE`.
 #' It should always return a string (a character vector of length one).
+#' The default method forwards to [vctrs::vec_ptype_abbr()] as of pillar v1.6.1,
+#' previous versions forwarded to [type_sum()].
 #'
-#' @keywords internal
 #' @examples
 #' obj_sum(1:10)
 #' obj_sum(matrix(1:10))

--- a/R/type-sum.R
+++ b/R/type-sum.R
@@ -67,8 +67,9 @@ vec_ptype_abbr.pillar_empty_col <- function(x, ...) {
 #' `obj_sum()` also includes the size (but not the shape) of the object
 #' if [vctrs::vec_is()] is `TRUE`.
 #' It should always return a string (a character vector of length one).
-#' The default method forwards to [vctrs::vec_ptype_abbr()] as of pillar v1.6.1,
-#' previous versions forwarded to [type_sum()].
+#' As of pillar v1.6.1, the default method forwards to [vctrs::vec_ptype_abbr()]
+#' for vectors and to [type_sum()] for other objects.
+#' Previous versions always forwarded to [type_sum()].
 #'
 #' @examples
 #' obj_sum(1:10)

--- a/man/type_sum.Rd
+++ b/man/type_sum.Rd
@@ -21,9 +21,11 @@ and variants have been implemented.}
 occur in a data frame should return a string with four or less characters.
 For most inputs, the argument is forwarded to \code{\link[vctrs:vec_ptype_full]{vctrs::vec_ptype_abbr()}}.
 
-\code{obj_sum()} also includes the size of the object if \code{\link[vctrs:vec_assert]{vctrs::vec_is()}}
-is \code{TRUE}.
+\code{obj_sum()} also includes the size (but not the shape) of the object
+if \code{\link[vctrs:vec_assert]{vctrs::vec_is()}} is \code{TRUE}.
 It should always return a string (a character vector of length one).
+The default method forwards to \code{\link[vctrs:vec_ptype_full]{vctrs::vec_ptype_abbr()}} as of pillar v1.6.1,
+previous versions forwarded to \code{\link[=type_sum]{type_sum()}}.
 
 \code{size_sum()} is called by \code{obj_sum()} to format the size of the object.
 It should always return a string (a character vector of length one),

--- a/man/type_sum.Rd
+++ b/man/type_sum.Rd
@@ -24,8 +24,9 @@ For most inputs, the argument is forwarded to \code{\link[vctrs:vec_ptype_full]{
 \code{obj_sum()} also includes the size (but not the shape) of the object
 if \code{\link[vctrs:vec_assert]{vctrs::vec_is()}} is \code{TRUE}.
 It should always return a string (a character vector of length one).
-The default method forwards to \code{\link[vctrs:vec_ptype_full]{vctrs::vec_ptype_abbr()}} as of pillar v1.6.1,
-previous versions forwarded to \code{\link[=type_sum]{type_sum()}}.
+As of pillar v1.6.1, the default method forwards to \code{\link[vctrs:vec_ptype_full]{vctrs::vec_ptype_abbr()}}
+for vectors and to \code{\link[=type_sum]{type_sum()}} for other objects.
+Previous versions always forwarded to \code{\link[=type_sum]{type_sum()}}.
 
 \code{size_sum()} is called by \code{obj_sum()} to format the size of the object.
 It should always return a string (a character vector of length one),


### PR DESCRIPTION
in particular the ignorance of `type_sum()` .

Closes #321.