### PR TITLE
Avoid collapsing pillars when fitting

### DIFF
--- a/R/ctl_colonnade.R
+++ b/R/ctl_colonnade.R
@@ -28,8 +28,7 @@ ctl_colonnade <- function(x, has_row_id = TRUE, width = NULL, controller = new_t
     return(new_colonnade_body(list(), extra_cols = x))
   }
 
-  compound_pillar <- combine_pillars(pillars)
-  col_widths <- colonnade_get_width_2(compound_pillar, tier_widths)
+  col_widths <- colonnade_get_width_2(pillars, tier_widths)
 
   tiers <- split(seq_len(nrow(col_widths)), col_widths$tier)
 
@@ -113,12 +112,12 @@ new_colonnade_body <- function(x, extra_cols) {
 }
 
 #' @noRd
-colonnade_get_width_2 <- function(compound_pillar, tier_widths) {
+colonnade_get_width_2 <- function(pillars, tier_widths) {
   "!!!!!DEBUG colonnade_get_width_2(`v(tier_widths)`)"
 
   #' @details
-  #' Each pillar indiacates its maximum and minimum width.
-  min_max_widths <- colonnade_get_min_max_widths(compound_pillar)
+  #' Each pillar indicates its maximum and minimum width.
+  min_max_widths <- colonnade_get_min_max_widths(pillars)
   #'
   #' Pillars may be distributed over multiple tiers according to their width
   #' if `width > getOption("width")`.
@@ -134,15 +133,14 @@ colonnade_get_width_2 <- function(compound_pillar, tier_widths) {
   out <- colonnade_distribute_space_df(col_widths_df, tier_widths)
   # out <- data.frame(id = numeric(), widths = numeric(), tier = numeric())
 
-  # FIXME: Defer split of compound pillars
-  out$pillar <- map(out$id, get_sub_pillar, x = compound_pillar)
+  out$pillar <- pillars
 
   new_tbl(out)
 }
 
-colonnade_get_min_max_widths <- function(compound_pillar) {
-  max_width <- exec(pmax, !!!unname(map(compound_pillar, get_cell_widths)))
-  min_width <- exec(pmax, !!!unname(map(compound_pillar, get_cell_min_widths)))
+colonnade_get_min_max_widths <- function(pillars) {
+  max_width <- map_int(pillars, pillar_get_total_widths)
+  min_width <- map_int(pillars, pillar_get_total_min_widths)
 
   new_tbl(list(min_width = min_width, max_width = max_width))
 }

--- a/R/ctl_compound.R
+++ b/R/ctl_compound.R
@@ -1,6 +1,6 @@
 new_data_frame_pillar <- function(x, controller, width, title) {
   pillars <- new_packed_pillars(x, controller, width, title)
-  combine_pillars(pillars)
+  combine_pillars(pillars, extra = names(x)[-seq_along(pillars)])
 }
 
 new_packed_pillars <- function(x, controller, width, title) {
@@ -111,7 +111,13 @@ new_matrix_pillar <- function(x, controller, width, title) {
     pillars[[i]] <- pillar
   }
 
-  combine_pillars(compact(pillars))
+  compact_pillars <- compact(pillars)
+  if (length(compact_pillars) < ncol(x)) {
+    extra <- seq2(length(compact_pillars) + 1, ncol(x))
+  } else {
+    extra <- NULL
+  }
+  combine_pillars(compact_pillars, extra = extra)
 }
 
 new_array_pillar <- function(x, controller, width, title) {
@@ -127,7 +133,7 @@ new_array_pillar <- function(x, controller, width, title) {
   )
 }
 
-combine_pillars <- function(pillars) {
+combine_pillars <- function(pillars, extra = NULL) {
   "!!!!!DEBUG combine_pillars(`v(length(pillars))`)"
 
   if (length(pillars) == 0) {
@@ -148,7 +154,7 @@ combine_pillars <- function(pillars) {
     )
   })
 
-  new_pillar(t_pillars, class = "compound_pillar")
+  new_pillar(t_pillars, class = "compound_pillar", extra = extra)
 }
 
 # Can be rewritten with a repeat loop

--- a/R/ctl_pillar.R
+++ b/R/ctl_pillar.R
@@ -99,7 +99,8 @@ pillar_from_shaft <- function(title, type, data, width) {
 }
 
 rowidformat2 <- function(data, names, has_star) {
-  out <- map(set_names(names), function(.x) "")
+  empty_component <- pillar_component(set_width("", 0))
+  out <- map(set_names(names), function(.x) empty_component)
 
   if ("type" %in% names) {
     out$type <- pillar_component(rif_type(has_star))
@@ -109,7 +110,7 @@ rowidformat2 <- function(data, names, has_star) {
     out$data <- pillar_component(data)
   }
 
-  new_pillar(out)
+  new_pillar(out, width = get_width(data))
 }
 
 #' Construct a custom pillar object

--- a/R/ctl_pillar.R
+++ b/R/ctl_pillar.R
@@ -194,8 +194,9 @@ print.compound_pillar <- function(x, ...) {
   writeLines(style_bold(desc))
   print(format(x, ...))
 
-  if (len > 1) {
-    writeLines(style_subtle(pre_dots(paste0("and ", len - 1, " more sub-pillars"))))
+  n_extra <- length(attr(x, "extra"))
+  if (n_extra > 0) {
+    writeLines(style_subtle(pre_dots(paste0("and ", n_extra, " more sub-pillars"))))
   }
 
   invisible(x)

--- a/R/ctl_pillar.R
+++ b/R/ctl_pillar.R
@@ -132,6 +132,8 @@ rowidformat2 <- function(data, names, has_star) {
 #' @inheritParams pillar
 #' @param components A named list of components constructed with [pillar_component()].
 #' @param class Name of subclass.
+#' @param extra For compound pillars, indicate the names or indices of the
+#'   sub-pillars that could not be shown due to width constraints.
 #'
 #' @export
 #' @examples
@@ -148,7 +150,8 @@ rowidformat2 <- function(data, names, has_star) {
 #'   title = pillar_component(new_ornament(c("abc", "de"), align = "right")),
 #'   lines = new_pillar_component(list(lines("=")), width = 1)
 #' ))
-new_pillar <- function(components, ..., width = NULL, class = NULL) {
+new_pillar <- function(components, ..., width = NULL, class = NULL,
+                       extra = NULL) {
   "!!!!DEBUG new_pillar(`v(width)`, `v(class)`)"
 
   check_dots_empty()
@@ -159,7 +162,8 @@ new_pillar <- function(components, ..., width = NULL, class = NULL) {
   structure(
     components,
     width = width,
-    class = c(class, "pillar")
+    class = c(class, "pillar"),
+    extra = extra
   )
 }
 

--- a/R/ctl_pillar_component.R
+++ b/R/ctl_pillar_component.R
@@ -94,7 +94,7 @@ get_cells_for_hierarchy <- function(x, from, to) {
 
 pillar_get_total_widths <- function(x) {
   widths <- pillar_get_widths(x)
-  sum(widths) + length(widths) - 1L
+  as.integer(sum(widths) + length(widths) - 1L)
 }
 
 pillar_get_widths <- function(x) {
@@ -103,7 +103,7 @@ pillar_get_widths <- function(x) {
 
 pillar_get_total_min_widths <- function(x) {
   widths <- pillar_get_min_widths(x)
-  widths[[1]]
+  as.integer(widths[[1]])
 }
 
 pillar_get_min_widths <- function(x) {

--- a/R/ctl_pillar_component.R
+++ b/R/ctl_pillar_component.R
@@ -124,7 +124,10 @@ pillar_format_parts_2 <- function(x, width) {
   parts <- map2(idx, widths[idx], function(.x, .y) pillar_format_sub_part(x, .x, .y))
 
   max_extent <- sum(map_int(parts, `[[`, "max_extent")) + length(parts) - 1L
-  aligned <- exec(paste, !!!map(parts, function(.x) .x$aligned[[1]]))
+  aligned <- format_colonnade_tier_2(
+    map(parts, function(.x) .x$aligned[[1]]),
+    bidi = get_pillar_option_bidi()
+  )
 
   new_tbl(list(max_extent = max_extent, aligned = list(aligned)))
 }

--- a/R/ctl_pillar_component.R
+++ b/R/ctl_pillar_component.R
@@ -92,8 +92,18 @@ get_cells_for_hierarchy <- function(x, from, to) {
   abort("NYI: get_cells_for_hierarchy()")
 }
 
+pillar_get_total_widths <- function(x) {
+  widths <- pillar_get_widths(x)
+  sum(widths) + length(widths) - 1L
+}
+
 pillar_get_widths <- function(x) {
   exec(pmax, !!!map(x, get_cell_widths))
+}
+
+pillar_get_total_min_widths <- function(x) {
+  widths <- pillar_get_min_widths(x)
+  widths[[1]]
 }
 
 pillar_get_min_widths <- function(x) {

--- a/R/ctl_pillar_component.R
+++ b/R/ctl_pillar_component.R
@@ -101,7 +101,22 @@ pillar_get_min_widths <- function(x) {
 }
 
 pillar_format_parts_2 <- function(x, width) {
-  pillar_format_sub_part(x, 1, width)
+  widths <- pillar_get_widths(x)
+
+  if (length(widths) == 1) {
+    # Special case: use actual width passed by caller
+    return(pillar_format_sub_part(x, 1, width))
+  }
+
+  # FIXME: Squeeze sub-pillars?
+
+  idx <- which(cumsum(widths + 1L) <= width + 1L)
+  parts <- map2(idx, widths[idx], function(.x, .y) pillar_format_sub_part(x, .x, .y))
+
+  max_extent <- sum(map_int(parts, `[[`, "max_extent")) + length(parts) - 1L
+  aligned <- exec(paste, !!!map(parts, function(.x) .x$aligned[[1]]))
+
+  new_tbl(list(max_extent = max_extent, aligned = list(aligned)))
 }
 
 pillar_format_sub_part <- function(x, i, width) {

--- a/R/ctl_pillar_component.R
+++ b/R/ctl_pillar_component.R
@@ -101,8 +101,11 @@ pillar_get_min_widths <- function(x) {
 }
 
 pillar_format_parts_2 <- function(x, width) {
-  # Code is repeated in ctl_colonnade
-  formatted <- map(x, function(.x) format(.x[[1]], width = width))
+  pillar_format_sub_part(x, 1, width)
+}
+
+pillar_format_sub_part <- function(x, i, width) {
+  formatted <- map(x, function(.x) format(.x[[i]], width = width))
 
   align <- attr(formatted[["data"]], "align", exact = TRUE) %||% "left"
 

--- a/R/pillar.R
+++ b/R/pillar.R
@@ -15,7 +15,7 @@ new_pillar_1e <- function(capital, shaft, width = NULL) {
 
 #' @export
 format.pillar_1e <- function(x, width = NULL, ...) {
-  width <- pillar_get_width(x, width)
+  width <- pillar_get_width_1e(x, width)
   out <- pillar_format_parts(x, width)
 
   as_glue(unlist(unname(out)))
@@ -27,7 +27,7 @@ print.pillar_1e <- function(x, ...) {
   print(format(x, ...))
 }
 
-pillar_get_width <- function(x, width) {
+pillar_get_width_1e <- function(x, width) {
   if (is.null(width)) {
     width <- get_width(x)
   }

--- a/TODO.md
+++ b/TODO.md
@@ -2,16 +2,8 @@
 
 ## Next steps
 
-- Multi-stage (hierarchical) output for packed data frames
-    - Challenging with tiers
-    - Show number of columns in the parent stage?
-        - If too wide; also show ellipsis
-        - Perhaps show column names in footer?
-    - Can we agree that a packed data frame never spans multiple tiers?
-
 - Focus columns at their native position, with ... or subtle vertical pipe inbetween (1 char wide)
     - Easiest if focus columns are moved to the beginning
-    - Requires multi-stage output?
     - Get extra width?
 
 - Breaking changes
@@ -40,6 +32,12 @@
     - `shorten = "unique"`? <https://github.com/r-lib/pillar/issues/101>
     - `shorten = "front"`: right-align?
     - control `NA` and zero characters: <https://github.com/r-lib/pillar/issues/151>
+    - Multi-stage (hierarchical) output for packed data frames
+        - Show number of columns in the parent stage?
+            - If too wide; also show ellipsis
+            - Perhaps show column names in footer?
+        - Distribute compound pillars over multiple tiers
+            - Or can we agree that a packed data frame never spans multiple tiers?
 - Resolve vctrs imports
 - Help with {errors} and {quantities}
 - Rethink tibble-local options for display: section "Rule-based formatting" in `numbers.Rmd`

--- a/TODO.md
+++ b/TODO.md
@@ -34,6 +34,7 @@
     - control `NA` and zero characters: <https://github.com/r-lib/pillar/issues/151>
     - Multi-stage (hierarchical) output for packed data frames
         - Show number of columns in the parent stage?
+            - Search for `sub_title <- c(title, ticked_names[[i]])`
             - If too wide; also show ellipsis
             - Perhaps show column names in footer?
         - Distribute compound pillars over multiple tiers

--- a/man/new_pillar.Rd
+++ b/man/new_pillar.Rd
@@ -4,7 +4,7 @@
 \alias{new_pillar}
 \title{Construct a custom pillar object}
 \usage{
-new_pillar(components, ..., width = NULL, class = NULL)
+new_pillar(components, ..., width = NULL, class = NULL, extra = NULL)
 }
 \arguments{
 \item{components}{A named list of components constructed with \code{\link[=pillar_component]{pillar_component()}}.}
@@ -14,6 +14,9 @@ new_pillar(components, ..., width = NULL, class = NULL)
 \item{width}{Default width, optional.}
 
 \item{class}{Name of subclass.}
+
+\item{extra}{For compound pillars, indicate the names or indices of the
+sub-pillars that could not be shown due to width constraints.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}

--- a/tests/testthat/_snaps/ctl_compound.md
+++ b/tests/testthat/_snaps/ctl_compound.md
@@ -8,12 +8,12 @@
       <tbl_format_header(setup)>
       # A data frame: 1 x 2
       <tbl_format_body(setup)>
-            a   b$x
-        <dbl> <dbl>
-      1     3     1
-           $y
+            a
         <dbl>
-      1     2
+      1     3
+          b$x    $y
+        <dbl> <dbl>
+      1     1     2
       <tbl_format_footer(setup)>
     Code
       options(width = 10)
@@ -29,8 +29,5 @@
           b$x
         <dbl>
       1     1
-           $y
-        <dbl>
-      1     2
       <tbl_format_footer(setup)>
 

--- a/tests/testthat/_snaps/ctl_new_pillar.md
+++ b/tests/testthat/_snaps/ctl_new_pillar.md
@@ -25,11 +25,11 @@
       ctl_new_compound_pillar(new_tbl(), trees[1:3, ], width = 20, title = "a")
     Output
       <compound_pillar[2]>
-              a$Girth
-                <dbl>
-                  8.3
-                  8.6
-                  8.8
+      a$Girth $Height
+        <dbl>   <dbl>
+          8.3      70
+          8.6      65
+          8.8      63
       ... and 1 more sub-pillars
     Code
       ctl_new_compound_pillar(new_tbl(), as.matrix(trees[1:3, ]), width = 20, title = "a")
@@ -40,16 +40,16 @@
               8.3
               8.6
               8.8
+      ... and 2 more sub-pillars
     Code
       ctl_new_compound_pillar(new_tbl(), matrix(1:6, ncol = 2), width = 20, title = "a")
     Output
       <compound_pillar[2]>
-            a[,1]
-            <int>
-                1
-                2
-                3
-      ... and 1 more sub-pillars
+      a[,1]  [,2]
+      <int> <int>
+          1     4
+          2     5
+          3     6
 
 # ctl_new_compound_pillar() for tables
 

--- a/tests/testthat/_snaps/ctl_new_pillar.md
+++ b/tests/testthat/_snaps/ctl_new_pillar.md
@@ -50,6 +50,15 @@
           1     4
           2     5
           3     6
+    Code
+      ctl_new_compound_pillar(new_tbl(), matrix(1:6, ncol = 3), width = 10, title = "a")
+    Output
+      <compound_pillar[1]>
+      a[,1]
+      <int>
+          1
+          2
+      ... and 2 more sub-pillars
 
 # ctl_new_compound_pillar() for tables
 

--- a/tests/testthat/test-ctl_new_pillar.R
+++ b/tests/testthat/test-ctl_new_pillar.R
@@ -10,6 +10,7 @@ test_that("ctl_new_compound_pillar()", {
     ctl_new_compound_pillar(new_tbl(), trees[1:3, ], width = 20, title = "a")
     ctl_new_compound_pillar(new_tbl(), as.matrix(trees[1:3, ]), width = 20, title = "a")
     ctl_new_compound_pillar(new_tbl(), matrix(1:6, ncol = 2), width = 20, title = "a")
+    ctl_new_compound_pillar(new_tbl(), matrix(1:6, ncol = 3), width = 10, title = "a")
   })
 })
 


### PR DESCRIPTION
Prerequisite for focus columns.

Breaking: compound pillars are no longer distributed over multiple tiers. We can reenable this later if necessary.