### PR TITLE
Keep trailing backtick when abbreviating column header

### DIFF
--- a/R/tick.R
+++ b/R/tick.R
@@ -1,5 +1,25 @@
 format_title <- function(x, width) {
-  align(str_trunc(x, width))
+  out <- align(str_trunc(x, width))
+
+  # HACK: Abbreviating text inbetween ticks
+  ticked <- grepl("^`", x)
+  if (!any(ticked)) {
+    return(out)
+  }
+
+  ticked[which(get_extent(x[ticked]) <= width)] <- FALSE
+  if (!any(ticked)) {
+    return(out)
+  }
+
+  x_ticked <- x[ticked]
+  rx <- "^`(.*)(`[^`]*)$"
+  match <- gsub(rx, "\\1", x[ticked])
+  rest <- gsub(rx, "\\2", x[ticked])
+
+  short <- str_trunc(match, width + get_extent(match) - get_extent(x_ticked))
+  out[ticked] <- align(paste0("`", short, rest))
+  out
 }
 
 tick_if_needed <- function(x) {

--- a/tests/testthat/test-ticks.R
+++ b/tests/testthat/test-ticks.R
@@ -11,6 +11,6 @@ test_that("title ticks and width", {
   expect_equal(format_title("proper_title", 10), continue("proper_ti"))
   expect_equal(format_title("`a b`", 6), "`a b`")
   expect_equal(format_title("`a b`", 5), "`a b`")
-  expect_equal(format_title("`a b`", 4), continue("`a "))
-  expect_equal(format_title("`a b`", 3), continue("`a"))
+  expect_equal(format_title("`a b`", 4), tick(continue("a")))
+  expect_equal(format_title("`a b`", 3), tick(continue("")))
 })


### PR DESCRIPTION
Closes tidyverse/tibble#838.