### PR TITLE
Show list of abbreviated columns

### DIFF
--- a/R/ctl_colonnade.R
+++ b/R/ctl_colonnade.R
@@ -84,9 +84,13 @@ ctl_colonnade <- function(x, has_row_id = TRUE, width = NULL,
     last_abbrev_title <<- title
   }
 
+  on_get_n_abbrev_cols <- function() {
+    length(abbrev_cols)
+  }
+
   cb <- new_emit_tiers_callbacks(
     controller, rowid, rowid_width, has_star,
-    on_tier, on_extra_cols, on_abbrev_col
+    on_tier, on_extra_cols, on_abbrev_col, on_get_n_abbrev_cols
   )
 
   # Side effect: populate formatted_tiers, extra_cols, and abbrev_cols
@@ -96,7 +100,7 @@ ctl_colonnade <- function(x, has_row_id = TRUE, width = NULL,
 }
 
 new_emit_tiers_callbacks <- function(controller, rowid, rowid_width, has_star,
-                                     on_tier, on_extra_cols, on_abbrev_col) {
+                                     on_tier, on_extra_cols, on_abbrev_col, on_get_n_abbrev_cols) {
   list(
     controller = controller,
     rowid = rowid,
@@ -104,7 +108,8 @@ new_emit_tiers_callbacks <- function(controller, rowid, rowid_width, has_star,
     has_star = has_star,
     on_tier = on_tier,
     on_extra_cols = on_extra_cols,
-    on_abbrev_col = on_abbrev_col
+    on_abbrev_col = on_abbrev_col,
+    on_get_n_abbrev_cols = on_get_n_abbrev_cols
   )
 }
 
@@ -159,7 +164,8 @@ do_emit_tiers <- function(x, tier_widths, n_focus, cb, focus) {
     on_pillar = on_pillar,
     on_top_level_pillar = function(...) {},
     on_extra_cols = on_extra_cols,
-    on_abbrev_col = cb$on_abbrev_col
+    on_abbrev_col = cb$on_abbrev_col,
+    on_get_n_abbrev_cols = cb$on_get_n_abbrev_cols
   )
 
   # Side effect: populate `extra_cols`,
@@ -175,7 +181,8 @@ new_emit_pillars_callbacks <- function(controller,
                                        on_pillar,
                                        on_top_level_pillar,
                                        on_extra_cols,
-                                       on_abbrev_col) {
+                                       on_abbrev_col,
+                                       on_get_n_abbrev_cols) {
   list(
     controller = controller,
     on_start_tier = on_start_tier,
@@ -183,7 +190,8 @@ new_emit_pillars_callbacks <- function(controller,
     on_pillar = on_pillar,
     on_top_level_pillar = on_top_level_pillar,
     on_extra_cols = on_extra_cols,
-    on_abbrev_col = on_abbrev_col
+    on_abbrev_col = on_abbrev_col,
+    on_get_n_abbrev_cols = on_get_n_abbrev_cols
   )
 }
 
@@ -239,7 +247,8 @@ do_emit_focus_pillars <- function(x, tier_widths, cb, focus) {
     on_pillar = on_focus_pillar,
     on_top_level_pillar = on_focus_top_level_pillar,
     on_extra_cols = on_focus_extra_cols,
-    on_abbrev_col = cb$on_abbrev_col
+    on_abbrev_col = cb$on_abbrev_col,
+    on_get_n_abbrev_cols = cb$on_get_n_abbrev_cols
   )
 
   # Side effect: populates focus_formatted_list and focus_extra_cols
@@ -384,7 +393,12 @@ do_emit_pillars <- function(x, tier_widths, cb, title = NULL, first_pillar = NUL
 
     title_width <- get_width(pillar[["title"]]) %||% 0L
 
-    formatted <- pillar_format_parts_2(pillar, max(tier_widths), is_focus)
+    formatted <- pillar_format_parts_2(
+      pillar,
+      max(tier_widths),
+      is_focus,
+      cb$on_get_n_abbrev_cols() + 1L
+    )
     true_width <- formatted$max_extent
     stopifnot(true_width <= max(tier_widths))
 

--- a/R/ctl_pillar_component.R
+++ b/R/ctl_pillar_component.R
@@ -68,11 +68,12 @@ pillar_get_min_width <- function(x) {
   as.integer(max(map_int(x, get_min_width)))
 }
 
-pillar_format_parts_2 <- function(x, width, is_focus = FALSE) {
+pillar_format_parts_2 <- function(x, width, is_focus = FALSE, footnote_idx = 1L) {
   formatted <- map(x, function(.x) format(
     .x[[1L]],
     width = min(width, get_width(.x)),
-    is_focus = is_focus
+    is_focus = is_focus,
+    footnote_idx = footnote_idx
   ))
 
   align <- attr(formatted[["data"]], "align", exact = TRUE) %||% "left"

--- a/R/tbl-format-footer.R
+++ b/R/tbl-format-footer.R
@@ -91,6 +91,7 @@ format_footer_abbrev_cols <- function(x, setup) {
     return(NULL)
   }
 
+  abbrev_cols <- paste0(map_chr(seq_along(abbrev_cols), superdigit_pre), abbrev_cols)
   idx_all_but_last <- seq_len(abbrev_cols_total - 1)
   abbrev_cols[idx_all_but_last] <- paste0(abbrev_cols[idx_all_but_last], ",")
 

--- a/R/tbl-format-footer.R
+++ b/R/tbl-format-footer.R
@@ -46,16 +46,17 @@ tbl_format_footer.tbl <- function(x, setup, ...) {
 
 format_footer <- function(x, setup) {
   extra_rows <- format_footer_extra_rows(x, setup)
+  abbrev_cols <- format_footer_abbrev_cols(x, setup)
   extra_cols <- format_footer_extra_cols(x, setup)
 
-  footer <- compact(list(extra_rows, extra_cols))
+  footer <- compact(list(extra_rows, abbrev_cols, extra_cols))
   if (length(footer) == 0) {
     return(character())
   }
 
   if (length(footer) > 1) {
     footer_len <- length(footer)
-    idx_all_but_last <- seq.int(footer_len - 1)
+    idx_all_but_last <- seq2(1, footer_len - 1)
     footer[idx_all_but_last] <- map(footer[idx_all_but_last], function(x) {
       x[[length(x)]] <- paste0(x[[length(x)]], ",")
       x
@@ -81,6 +82,23 @@ format_footer_extra_rows <- function(x, setup) {
       c("at", "least", big_mark(rows_body), pluralise_n("row(s)", rows_body), "total")
     }
   }
+}
+
+format_footer_abbrev_cols <- function(x, setup) {
+  abbrev_cols <- setup$abbrev_cols
+  abbrev_cols_total <- length(abbrev_cols)
+  if (abbrev_cols_total == 0) {
+    return(NULL)
+  }
+
+  idx_all_but_last <- seq2(1, abbrev_cols_total - 1)
+  abbrev_cols[idx_all_but_last] <- paste0(abbrev_cols[idx_all_but_last], ",")
+
+  c(
+    "abbreviated", "variable",
+    pluralise("name(s)", abbrev_cols),
+    abbrev_cols
+  )
 }
 
 format_footer_extra_cols <- function(x, setup) {

--- a/R/tbl-format-footer.R
+++ b/R/tbl-format-footer.R
@@ -91,7 +91,7 @@ format_footer_abbrev_cols <- function(x, setup) {
     return(NULL)
   }
 
-  idx_all_but_last <- seq2(1, abbrev_cols_total - 1)
+  idx_all_but_last <- seq_len(abbrev_cols_total - 1)
   abbrev_cols[idx_all_but_last] <- paste0(abbrev_cols[idx_all_but_last], ",")
 
   c(

--- a/R/tick.R
+++ b/R/tick.R
@@ -1,4 +1,4 @@
-format_title <- function(x, width, footnote = FALSE) {
+format_title <- function(x, width, footnote = TRUE) {
   align(str_trunc(x, width, if (footnote) "untick_footnote" else "untick"))
 }
 

--- a/R/title.R
+++ b/R/title.R
@@ -51,7 +51,7 @@ get_min_title_width <- function(width) {
 }
 
 #' @export
-format.pillar_title <- function(x, width = NULL, ...) {
+format.pillar_title <- function(x, width = NULL, ..., footnote_idx = 1L) {
   title <- x[[1]]
   if (is.null(title)) {
     return(character())
@@ -61,6 +61,10 @@ format.pillar_title <- function(x, width = NULL, ...) {
     width <- get_width(x)
   }
 
-  title <- format_title(title, width)
+  footnote <- (footnote_idx > 0L)
+  title <- format_title(title, width, footnote)
+  if (footnote) {
+    title <- gsub("\u02df$", superdigit(footnote_idx), title)
+  }
   style_title(title)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -169,3 +169,25 @@ vec_lag <- function(x, default = vec_slice(x, NA_integer_)) {
   }
   vec_c(default, vec_slice(x, -n))
 }
+
+super <- c(
+  "\u00b9", "\u00b2", "\u00b3", "\u2074",
+  "\u2075", "\u2076", "\u2077", "\u2078", "\u2079",
+  "\u02df"
+)
+
+superdigit <- function(x) {
+  if (cli::is_utf8_output()) {
+    super[[min(x, 10)]]
+  } else {
+    if (x >= 10) "*" else as.character(x)
+  }
+}
+
+superdigit_pre <- function(x) {
+  if (cli::is_utf8_output()) {
+    superdigit(x)
+  } else {
+    paste0(superdigit(x), ": ")
+  }
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -186,7 +186,7 @@ superdigit <- function(x) {
 
 superdigit_pre <- function(x) {
   if (cli::is_utf8_output()) {
-    superdigit(x)
+    paste0(superdigit(x), " ")
   } else {
     paste0(superdigit(x), ": ")
   }

--- a/tests/testthat/_snaps/ansi/ctl_colonnade.md
+++ b/tests/testthat/_snaps/ansi/ctl_colonnade.md
@@ -151,7 +151,7 @@
       ctl_colonnade(list(a_very_long_column_name = 0), width = 20)
     Output
       $body
-        a_very_long_colum~
+        a_very_long_colu~1
                      [3m[90m<dbl>[39m[23m
       [90m1[39m                  0
       

--- a/tests/testthat/_snaps/format_multi.md
+++ b/tests/testthat/_snaps/format_multi.md
@@ -44,7 +44,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        col~˟
+        col~1
         <dbl>
       1  1.23
       2  2.23
@@ -56,7 +56,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        colu~˟
+        colu~1
          <dbl>
       1   1.23
       2   2.23
@@ -68,7 +68,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        colum~˟
+        colum~1
           <dbl>
       1    1.23
       2    2.23
@@ -80,7 +80,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column~˟
+        column~1
            <dbl>
       1     1.23
       2     2.23
@@ -92,7 +92,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_~˟
+        column_~1
             <dbl>
       1      1.23
       2      2.23
@@ -104,7 +104,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_z~˟
+        column_z~1
              <dbl>
       1       1.23
       2       2.23
@@ -116,7 +116,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_ze~˟
+        column_ze~1
               <dbl>
       1        1.23
       2        2.23
@@ -128,7 +128,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zer~˟
+        column_zer~1
                <dbl>
       1         1.23
       2         2.23
@@ -140,7 +140,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero~˟
+        column_zero~1
                 <dbl>
       1          1.23
       2          2.23
@@ -152,7 +152,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_~˟
+        column_zero_~1
                  <dbl>
       1           1.23
       2           2.23

--- a/tests/testthat/_snaps/format_multi.md
+++ b/tests/testthat/_snaps/format_multi.md
@@ -44,7 +44,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        colu~
+        col~˟
         <dbl>
       1  1.23
       2  2.23
@@ -56,7 +56,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        colum~
+        colu~˟
          <dbl>
       1   1.23
       2   2.23
@@ -68,7 +68,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column~
+        colum~˟
           <dbl>
       1    1.23
       2    2.23
@@ -80,7 +80,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_~
+        column~˟
            <dbl>
       1     1.23
       2     2.23
@@ -92,7 +92,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_z~
+        column_~˟
             <dbl>
       1      1.23
       2      2.23
@@ -104,7 +104,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_ze~
+        column_z~˟
              <dbl>
       1       1.23
       2       2.23
@@ -116,7 +116,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zer~
+        column_ze~˟
               <dbl>
       1        1.23
       2        2.23
@@ -128,7 +128,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero~
+        column_zer~˟
                <dbl>
       1         1.23
       2         2.23
@@ -140,7 +140,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_~
+        column_zero~˟
                 <dbl>
       1          1.23
       2          2.23
@@ -152,7 +152,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_o~
+        column_zero_~˟
                  <dbl>
       1           1.23
       2           2.23

--- a/tests/testthat/_snaps/tbl-format-footer.md
+++ b/tests/testthat/_snaps/tbl-format-footer.md
@@ -72,13 +72,13 @@
       tbl_format_footer(tbl_format_setup(new_footer_tbl("a_very_long_prefix_")))
     Output
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable names a_very_long_prefix_ab,
-      #   a_very_long_prefix_bb, and 48 more variables: a_very_long_prefix_ac <int>,
-      #   a_very_long_prefix_bc <int>, a_very_long_prefix_ad <int>,
-      #   a_very_long_prefix_bd <int>, a_very_long_prefix_ae <int>,
-      #   a_very_long_prefix_be <int>, a_very_long_prefix_af <int>,
-      #   a_very_long_prefix_bf <int>, a_very_long_prefix_ag <int>,
-      #   a_very_long_prefix_bg <int>, a_very_long_prefix_ah <int>, ...
+      # ... with abbreviated variable names 1: a_very_long_prefix_ab,
+      #   2: a_very_long_prefix_bb, and 48 more variables:
+      #   a_very_long_prefix_ac <int>, a_very_long_prefix_bc <int>,
+      #   a_very_long_prefix_ad <int>, a_very_long_prefix_bd <int>,
+      #   a_very_long_prefix_ae <int>, a_very_long_prefix_be <int>,
+      #   a_very_long_prefix_af <int>, a_very_long_prefix_bf <int>,
+      #   a_very_long_prefix_ag <int>, a_very_long_prefix_bg <int>, ...
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl(""), max_footer_lines = 3))
     Output
@@ -98,9 +98,9 @@
       max_footer_lines = 3))
     Output
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable names a_very_long_prefix_ab,
-      #   a_very_long_prefix_bb, and 48 more variables: a_very_long_prefix_ac <int>,
-      #   a_very_long_prefix_bc <int>, a_very_long_prefix_ad <int>, ...
+      # ... with abbreviated variable names 1: a_very_long_prefix_ab,
+      #   2: a_very_long_prefix_bb, and 48 more variables:
+      #   a_very_long_prefix_ac <int>, a_very_long_prefix_bc <int>, ...
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl(""), max_footer_lines = Inf))
     Output
@@ -132,30 +132,30 @@
       max_footer_lines = Inf))
     Output
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable names a_very_long_prefix_ab,
-      #   a_very_long_prefix_bb, and 48 more variables: a_very_long_prefix_ac <int>,
-      #   a_very_long_prefix_bc <int>, a_very_long_prefix_ad <int>,
-      #   a_very_long_prefix_bd <int>, a_very_long_prefix_ae <int>,
-      #   a_very_long_prefix_be <int>, a_very_long_prefix_af <int>,
-      #   a_very_long_prefix_bf <int>, a_very_long_prefix_ag <int>,
-      #   a_very_long_prefix_bg <int>, a_very_long_prefix_ah <int>,
-      #   a_very_long_prefix_bh <int>, a_very_long_prefix_ai <int>,
-      #   a_very_long_prefix_bi <int>, a_very_long_prefix_aj <int>,
-      #   a_very_long_prefix_bj <int>, a_very_long_prefix_ak <int>,
-      #   a_very_long_prefix_bk <int>, a_very_long_prefix_al <int>,
-      #   a_very_long_prefix_bl <int>, a_very_long_prefix_am <int>,
-      #   a_very_long_prefix_bm <int>, a_very_long_prefix_an <int>,
-      #   a_very_long_prefix_bn <int>, a_very_long_prefix_ao <int>,
-      #   a_very_long_prefix_bo <int>, a_very_long_prefix_ap <int>,
-      #   a_very_long_prefix_bp <int>, a_very_long_prefix_aq <int>,
-      #   a_very_long_prefix_bq <int>, a_very_long_prefix_ar <int>,
-      #   a_very_long_prefix_br <int>, a_very_long_prefix_as <int>,
-      #   a_very_long_prefix_bs <int>, a_very_long_prefix_at <int>,
-      #   a_very_long_prefix_bt <int>, a_very_long_prefix_au <int>,
-      #   a_very_long_prefix_bu <int>, a_very_long_prefix_av <int>,
-      #   a_very_long_prefix_bv <int>, a_very_long_prefix_aw <int>,
-      #   a_very_long_prefix_bw <int>, a_very_long_prefix_ax <int>,
-      #   a_very_long_prefix_bx <int>, a_very_long_prefix_ay <int>,
-      #   a_very_long_prefix_by <int>, a_very_long_prefix_az <int>,
-      #   a_very_long_prefix_bz <int>
+      # ... with abbreviated variable names 1: a_very_long_prefix_ab,
+      #   2: a_very_long_prefix_bb, and 48 more variables:
+      #   a_very_long_prefix_ac <int>, a_very_long_prefix_bc <int>,
+      #   a_very_long_prefix_ad <int>, a_very_long_prefix_bd <int>,
+      #   a_very_long_prefix_ae <int>, a_very_long_prefix_be <int>,
+      #   a_very_long_prefix_af <int>, a_very_long_prefix_bf <int>,
+      #   a_very_long_prefix_ag <int>, a_very_long_prefix_bg <int>,
+      #   a_very_long_prefix_ah <int>, a_very_long_prefix_bh <int>,
+      #   a_very_long_prefix_ai <int>, a_very_long_prefix_bi <int>,
+      #   a_very_long_prefix_aj <int>, a_very_long_prefix_bj <int>,
+      #   a_very_long_prefix_ak <int>, a_very_long_prefix_bk <int>,
+      #   a_very_long_prefix_al <int>, a_very_long_prefix_bl <int>,
+      #   a_very_long_prefix_am <int>, a_very_long_prefix_bm <int>,
+      #   a_very_long_prefix_an <int>, a_very_long_prefix_bn <int>,
+      #   a_very_long_prefix_ao <int>, a_very_long_prefix_bo <int>,
+      #   a_very_long_prefix_ap <int>, a_very_long_prefix_bp <int>,
+      #   a_very_long_prefix_aq <int>, a_very_long_prefix_bq <int>,
+      #   a_very_long_prefix_ar <int>, a_very_long_prefix_br <int>,
+      #   a_very_long_prefix_as <int>, a_very_long_prefix_bs <int>,
+      #   a_very_long_prefix_at <int>, a_very_long_prefix_bt <int>,
+      #   a_very_long_prefix_au <int>, a_very_long_prefix_bu <int>,
+      #   a_very_long_prefix_av <int>, a_very_long_prefix_bv <int>,
+      #   a_very_long_prefix_aw <int>, a_very_long_prefix_bw <int>,
+      #   a_very_long_prefix_ax <int>, a_very_long_prefix_bx <int>,
+      #   a_very_long_prefix_ay <int>, a_very_long_prefix_by <int>,
+      #   a_very_long_prefix_az <int>, a_very_long_prefix_bz <int>
 

--- a/tests/testthat/_snaps/tbl-format-footer.md
+++ b/tests/testthat/_snaps/tbl-format-footer.md
@@ -72,13 +72,13 @@
       tbl_format_footer(tbl_format_setup(new_footer_tbl("a_very_long_prefix_")))
     Output
       <tbl_format_footer(setup)>
-      # ... with 48 more variables: a_very_long_prefix_ac <int>,
+      # ... with abbreviated variable names a_very_long_prefix_ab,
+      #   a_very_long_prefix_bb, and 48 more variables: a_very_long_prefix_ac <int>,
       #   a_very_long_prefix_bc <int>, a_very_long_prefix_ad <int>,
       #   a_very_long_prefix_bd <int>, a_very_long_prefix_ae <int>,
       #   a_very_long_prefix_be <int>, a_very_long_prefix_af <int>,
       #   a_very_long_prefix_bf <int>, a_very_long_prefix_ag <int>,
-      #   a_very_long_prefix_bg <int>, a_very_long_prefix_ah <int>,
-      #   a_very_long_prefix_bh <int>, a_very_long_prefix_ai <int>, ...
+      #   a_very_long_prefix_bg <int>, a_very_long_prefix_ah <int>, ...
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl(""), max_footer_lines = 3))
     Output
@@ -98,9 +98,9 @@
       max_footer_lines = 3))
     Output
       <tbl_format_footer(setup)>
-      # ... with 48 more variables: a_very_long_prefix_ac <int>,
-      #   a_very_long_prefix_bc <int>, a_very_long_prefix_ad <int>,
-      #   a_very_long_prefix_bd <int>, a_very_long_prefix_ae <int>, ...
+      # ... with abbreviated variable names a_very_long_prefix_ab,
+      #   a_very_long_prefix_bb, and 48 more variables: a_very_long_prefix_ac <int>,
+      #   a_very_long_prefix_bc <int>, a_very_long_prefix_ad <int>, ...
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl(""), max_footer_lines = Inf))
     Output
@@ -132,7 +132,8 @@
       max_footer_lines = Inf))
     Output
       <tbl_format_footer(setup)>
-      # ... with 48 more variables: a_very_long_prefix_ac <int>,
+      # ... with abbreviated variable names a_very_long_prefix_ab,
+      #   a_very_long_prefix_bb, and 48 more variables: a_very_long_prefix_ac <int>,
       #   a_very_long_prefix_bc <int>, a_very_long_prefix_ad <int>,
       #   a_very_long_prefix_bd <int>, a_very_long_prefix_ae <int>,
       #   a_very_long_prefix_be <int>, a_very_long_prefix_af <int>,

--- a/tests/testthat/_snaps/tbl-format-setup.md
+++ b/tests/testthat/_snaps/tbl-format-setup.md
@@ -1578,3 +1578,23 @@
       #   *: xxxbcd, *: xxxefg, *: xxxhij, and 2 more variables: xxxklm <dbl>,
       #   xxxnop <dbl>
 
+# tbl_format_setup() for footnotes with UTF-8 output
+
+    Code
+      tbl_format_setup(width = 73, as_tbl(data_frame(xxxabc = 1, xxxdef = 1, xxxghi = 1,
+        xxxjkl = 1, xxxmno = 1, xxxpqr = 1, xxxstu = 1, xxxvwx = 1, xxxyza = 1,
+        xxxbcd = 1, xxxefg = 1, xxxhij = 1, xxxklm = 1, xxxnop = 1)))
+    Output
+      <pillar_tbl_format_setup>
+      <tbl_format_header(setup)>
+      # A data frame: 1 × 14
+      <tbl_format_body(setup)>
+        xxx…¹ xxx…² xxx…³ xxx…⁴ xxx…⁵ xxx…⁶ xxx…⁷ xxx…⁸ xxx…⁹ xxx…˟ xxx…˟ xxx…˟
+        <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+      1     1     1     1     1     1     1     1     1     1     1     1     1
+      <tbl_format_footer(setup)>
+      # … with abbreviated variable names ¹ xxxabc, ² xxxdef, ³ xxxghi,
+      #   ⁴ xxxjkl, ⁵ xxxmno, ⁶ xxxpqr, ⁷ xxxstu, ⁸ xxxvwx, ⁹ xxxyza,
+      #   ˟ xxxbcd, ˟ xxxefg, ˟ xxxhij, and 2 more variables: xxxklm <dbl>,
+      #   xxxnop <dbl>
+

--- a/tests/testthat/_snaps/tbl-format-setup.md
+++ b/tests/testthat/_snaps/tbl-format-setup.md
@@ -527,7 +527,7 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col~`˟
+        column_zero_zero `col 01`$`col~`1
                    <dbl> <chr>           
       1             1.23 a               
       2             2.23 b               
@@ -678,7 +678,7 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col~`˟ `col 05`
+        column_zero_zero `col 01`$`col~`1 `col 05`
                    <dbl> <chr>            <ord>   
       1             1.23 a                a       
       2             2.23 b                b       
@@ -834,7 +834,7 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col~`˟ $`col 03` `col 05`
+        column_zero_zero `col 01`$`col~`1 $`col 03` `col 05`
                    <dbl> <chr>            <chr>     <ord>   
       1             1.23 a                A         a       
       2             2.23 b                B         b       
@@ -1061,7 +1061,7 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col~`˟ $`col 03` $`col 04`[,"A"] `col 05`
+        column_zero_zero `col 01`$`col~`1 $`col 03` $`col 04`[,"A"] `col 05`
                    <dbl> <chr>            <chr>               <int> <ord>   
       1             1.23 a                A                       1 a       
       2             2.23 b                B                       2 b       
@@ -1557,4 +1557,24 @@
       5     5
       <tbl_format_footer(setup)>
       # ... with more rows
+
+# tbl_format_setup() for footnotes
+
+    Code
+      tbl_format_setup(width = 73, as_tbl(data_frame(xxxabc = 1, xxxdef = 1, xxxghi = 1,
+        xxxjkl = 1, xxxmno = 1, xxxpqr = 1, xxxstu = 1, xxxvwx = 1, xxxyza = 1,
+        xxxbcd = 1, xxxefg = 1, xxxhij = 1, xxxklm = 1, xxxnop = 1)))
+    Output
+      <pillar_tbl_format_setup>
+      <tbl_format_header(setup)>
+      # A data frame: 1 x 14
+      <tbl_format_body(setup)>
+        xxx~1 xxx~2 xxx~3 xxx~4 xxx~5 xxx~6 xxx~7 xxx~8 xxx~9 xxx~* xxx~* xxx~*
+        <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl> <dbl>
+      1     1     1     1     1     1     1     1     1     1     1     1     1
+      <tbl_format_footer(setup)>
+      # ... with abbreviated variable names 1: xxxabc, 2: xxxdef, 3: xxxghi,
+      #   4: xxxjkl, 5: xxxmno, 6: xxxpqr, 7: xxxstu, 8: xxxvwx, 9: xxxyza,
+      #   *: xxxbcd, *: xxxefg, *: xxxhij, and 2 more variables: xxxklm <dbl>,
+      #   xxxnop <dbl>
 

--- a/tests/testthat/_snaps/tbl-format-setup.md
+++ b/tests/testthat/_snaps/tbl-format-setup.md
@@ -527,7 +527,7 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col ~`
+        column_zero_zero `col 01`$`col~`˟
                    <dbl> <chr>           
       1             1.23 a               
       2             2.23 b               
@@ -678,7 +678,7 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col ~` `col 05`
+        column_zero_zero `col 01`$`col~`˟ `col 05`
                    <dbl> <chr>            <ord>   
       1             1.23 a                a       
       2             2.23 b                b       
@@ -834,7 +834,7 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col ~` $`col 03` `col 05`
+        column_zero_zero `col 01`$`col~`˟ $`col 03` `col 05`
                    <dbl> <chr>            <chr>     <ord>   
       1             1.23 a                A         a       
       2             2.23 b                B         b       
@@ -1061,7 +1061,7 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col ~` $`col 03` $`col 04`[,"A"] `col 05`
+        column_zero_zero `col 01`$`col~`˟ $`col 03` $`col 04`[,"A"] `col 05`
                    <dbl> <chr>            <chr>               <int> <ord>   
       1             1.23 a                A                       1 a       
       2             2.23 b                B                       2 b       

--- a/tests/testthat/_snaps/tbl-format-setup.md
+++ b/tests/testthat/_snaps/tbl-format-setup.md
@@ -533,7 +533,9 @@
       2             2.23 b               
       3             3.23 c               
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
+      # ... with abbreviated variable
+      #   name `col 01`$`col 02`, and 3
+      #   more variables:
       #   `col 01`$`col 03` <chr>,
       #   $`col 04` <int[,3]>,
       #   `col 05` <ord>
@@ -682,8 +684,9 @@
       2             2.23 b                b       
       3             3.23 c                c       
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>,
+      # ... with abbreviated variable name
+      #   `col 01`$`col 02`, and 2 more
+      #   variables: `col 01`$`col 03` <chr>,
       #   $`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 45)
@@ -837,7 +840,8 @@
       2             2.23 b                B         b       
       3             3.23 c                C         c       
       <tbl_format_footer(setup)>
-      # ... with 1 more variable:
+      # ... with abbreviated variable name
+      #   `col 01`$`col 02`, and 1 more variable:
       #   `col 01`$`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 55)
@@ -1063,7 +1067,8 @@
       2             2.23 b                B                       2 b       
       3             3.23 c                C                       3 c       
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable name `col 01`$`col 02`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 71)
     Output

--- a/tests/testthat/_snaps/tbl-format-setup.md
+++ b/tests/testthat/_snaps/tbl-format-setup.md
@@ -534,8 +534,8 @@
       3             3.23 c               
       <tbl_format_footer(setup)>
       # ... with abbreviated variable
-      #   name `col 01`$`col 02`, and 3
-      #   more variables:
+      #   name 1: `col 01`$`col 02`, and
+      #   3 more variables:
       #   `col 01`$`col 03` <chr>,
       #   $`col 04` <int[,3]>,
       #   `col 05` <ord>
@@ -685,7 +685,7 @@
       3             3.23 c                c       
       <tbl_format_footer(setup)>
       # ... with abbreviated variable name
-      #   `col 01`$`col 02`, and 2 more
+      #   1: `col 01`$`col 02`, and 2 more
       #   variables: `col 01`$`col 03` <chr>,
       #   $`col 04` <int[,3]>
     Code
@@ -841,7 +841,7 @@
       3             3.23 c                C         c       
       <tbl_format_footer(setup)>
       # ... with abbreviated variable name
-      #   `col 01`$`col 02`, and 1 more variable:
+      #   1: `col 01`$`col 02`, and 1 more variable:
       #   `col 01`$`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 55)
@@ -1067,7 +1067,7 @@
       2             2.23 b                B                       2 b       
       3             3.23 c                C                       3 c       
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable name `col 01`$`col 02`, and 1 more
+      # ... with abbreviated variable name 1: `col 01`$`col 02`, and 1 more
       #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 71)

--- a/tests/testthat/_snaps/ticks.md
+++ b/tests/testthat/_snaps/ticks.md
@@ -1,41 +1,33 @@
 # title ticks and width
 
     Code
-      format_title("proper_title", 15)
+      format_title("proper_title", 15, footnote = FALSE)
     Output
       [1] "proper_title"
     Code
-      format_title("proper_title", 12)
+      format_title("proper_title", 12, footnote = FALSE)
     Output
       [1] "proper_title"
-    Code
-      format_title("proper_title", 10)
-    Output
-      [1] "proper_t~˟"
     Code
       format_title("proper_title", 10, footnote = FALSE)
     Output
       [1] "proper_ti~"
     Code
-      format_title("`a b`", 6)
+      format_title("`a b`", 6, footnote = FALSE)
     Output
       [1] "`a b`"
     Code
-      format_title("`a b`", 5)
+      format_title("`a b`", 5, footnote = FALSE)
     Output
       [1] "`a b`"
-    Code
-      format_title("`a b`", 4)
-    Output
-      [1] "`~`˟"
     Code
       format_title("`a b`", 4, footnote = FALSE)
     Output
       [1] "`a~`"
     Code
-      format_title("`a b`", 3)
+      format_title("`a b`", 3, footnote = FALSE)
     Output
-      [1] "~`˟"
+      [1] "`~`"
     Code
       format_title("`a b`", 3, footnote = FALSE)
     Output

--- a/tests/testthat/_snaps/ticks.md
+++ b/tests/testthat/_snaps/ticks.md
@@ -11,7 +11,7 @@
     Code
       format_title("proper_title", 10)
     Output
-      [1] "proper_ti~"
+      [1] "proper_t~˟"
     Code
       format_title("proper_title", 10, footnote = FALSE)
     Output
@@ -27,7 +27,7 @@
     Code
       format_title("`a b`", 4)
     Output
-      [1] "`a~`"
+      [1] "`~`˟"
     Code
       format_title("`a b`", 4, footnote = FALSE)
     Output
@@ -35,7 +35,7 @@
     Code
       format_title("`a b`", 3)
     Output
-      [1] "`~`"
+      [1] "~`˟"
     Code
       format_title("`a b`", 3, footnote = FALSE)
     Output

--- a/tests/testthat/_snaps/ticks.md
+++ b/tests/testthat/_snaps/ticks.md
@@ -1,0 +1,43 @@
+# title ticks and width
+
+    Code
+      format_title("proper_title", 15)
+    Output
+      [1] "proper_title"
+    Code
+      format_title("proper_title", 12)
+    Output
+      [1] "proper_title"
+    Code
+      format_title("proper_title", 10)
+    Output
+      [1] "proper_ti~"
+    Code
+      format_title("proper_title", 10, footnote = FALSE)
+    Output
+      [1] "proper_ti~"
+    Code
+      format_title("`a b`", 6)
+    Output
+      [1] "`a b`"
+    Code
+      format_title("`a b`", 5)
+    Output
+      [1] "`a b`"
+    Code
+      format_title("`a b`", 4)
+    Output
+      [1] "`a~`"
+    Code
+      format_title("`a b`", 4, footnote = FALSE)
+    Output
+      [1] "`a~`"
+    Code
+      format_title("`a b`", 3)
+    Output
+      [1] "`~`"
+    Code
+      format_title("`a b`", 3, footnote = FALSE)
+    Output
+      [1] "`~`"
+

--- a/tests/testthat/_snaps/title.md
+++ b/tests/testthat/_snaps/title.md
@@ -79,7 +79,7 @@
       width = 18)
     Output
       <pillar>
-      absolutely_breaki~
+      absolutely_break~˟
                    <dbl>
                       10
                      100

--- a/tests/testthat/_snaps/title.md
+++ b/tests/testthat/_snaps/title.md
@@ -79,7 +79,7 @@
       width = 18)
     Output
       <pillar>
-      absolutely_break~˟
+      absolutely_break~1
                    <dbl>
                       10
                      100

--- a/tests/testthat/_snaps/unicode/ctl_colonnade.md
+++ b/tests/testthat/_snaps/unicode/ctl_colonnade.md
@@ -151,7 +151,7 @@
       ctl_colonnade(list(a_very_long_column_name = 0), width = 20)
     Output
       $body
-        a_very_long_colum…
+        a_very_long_colu…˟
                      [3m[90m<dbl>[39m[23m
       [90m1[39m                  0
       

--- a/tests/testthat/_snaps/unicode/ctl_colonnade.md
+++ b/tests/testthat/_snaps/unicode/ctl_colonnade.md
@@ -151,7 +151,7 @@
       ctl_colonnade(list(a_very_long_column_name = 0), width = 20)
     Output
       $body
-        a_very_long_colu…˟
+        a_very_long_colu…¹
                      [3m[90m<dbl>[39m[23m
       [90m1[39m                  0
       

--- a/tests/testthat/_snaps/unicode/format_multi.md
+++ b/tests/testthat/_snaps/unicode/format_multi.md
@@ -117,7 +117,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        a_very_long…˟
+        a_very_long…¹
                 [3m[90m<dbl>[39m[23m
       [90m1[39m             0
 

--- a/tests/testthat/_snaps/unicode/format_multi.md
+++ b/tests/testthat/_snaps/unicode/format_multi.md
@@ -117,7 +117,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        a_very_long_…
+        a_very_long…˟
                 [3m[90m<dbl>[39m[23m
       [90m1[39m             0
 

--- a/tests/testthat/test-tbl-format-setup.R
+++ b/tests/testthat/test-tbl-format-setup.R
@@ -161,3 +161,29 @@ test_that("tbl_format_setup() for footnotes", {
     )))
   })
 })
+
+test_that("tbl_format_setup() for footnotes with UTF-8 output", {
+  skip_if(!l10n_info()$`UTF-8`)
+
+  local_pillar_option_min_title_chars(3)
+  local_utf8()
+
+  expect_snapshot({
+    tbl_format_setup(width = 73, as_tbl(data_frame(
+      xxxabc = 1,
+      xxxdef = 1,
+      xxxghi = 1,
+      xxxjkl = 1,
+      xxxmno = 1,
+      xxxpqr = 1,
+      xxxstu = 1,
+      xxxvwx = 1,
+      xxxyza = 1,
+      xxxbcd = 1,
+      xxxefg = 1,
+      xxxhij = 1,
+      xxxklm = 1,
+      xxxnop = 1
+    )))
+  })
+})

--- a/tests/testthat/test-tbl-format-setup.R
+++ b/tests/testthat/test-tbl-format-setup.R
@@ -138,3 +138,26 @@ test_that("tbl_format_setup() results", {
     )
   })
 })
+
+test_that("tbl_format_setup() for footnotes", {
+  local_pillar_option_min_title_chars(3)
+
+  expect_snapshot({
+    tbl_format_setup(width = 73, as_tbl(data_frame(
+      xxxabc = 1,
+      xxxdef = 1,
+      xxxghi = 1,
+      xxxjkl = 1,
+      xxxmno = 1,
+      xxxpqr = 1,
+      xxxstu = 1,
+      xxxvwx = 1,
+      xxxyza = 1,
+      xxxbcd = 1,
+      xxxefg = 1,
+      xxxhij = 1,
+      xxxklm = 1,
+      xxxnop = 1
+    )))
+  })
+})

--- a/tests/testthat/test-ticks.R
+++ b/tests/testthat/test-ticks.R
@@ -6,11 +6,16 @@ test_that("title ticks without width restriction", {
 })
 
 test_that("title ticks and width", {
-  expect_equal(format_title("proper_title", 15), "proper_title")
-  expect_equal(format_title("proper_title", 12), "proper_title")
-  expect_equal(format_title("proper_title", 10), continue("proper_ti"))
-  expect_equal(format_title("`a b`", 6), "`a b`")
-  expect_equal(format_title("`a b`", 5), "`a b`")
-  expect_equal(format_title("`a b`", 4), tick(continue("a")))
-  expect_equal(format_title("`a b`", 3), tick(continue("")))
+  expect_snapshot({
+    format_title("proper_title", 15)
+    format_title("proper_title", 12)
+    format_title("proper_title", 10)
+    format_title("proper_title", 10, footnote = FALSE)
+    format_title("`a b`", 6)
+    format_title("`a b`", 5)
+    format_title("`a b`", 4)
+    format_title("`a b`", 4, footnote = FALSE)
+    format_title("`a b`", 3)
+    format_title("`a b`", 3, footnote = FALSE)
+  })
 })

--- a/tests/testthat/test-ticks.R
+++ b/tests/testthat/test-ticks.R
@@ -5,17 +5,29 @@ test_that("title ticks without width restriction", {
   expect_equal(tick_if_needed("embedded\nnewline"), "`embedded\\nnewline`")
 })
 
-test_that("title ticks and width", {
+test_that("title ticks and width with footnote", {
+  skip_if(!cli::is_utf8_output())
+
   expect_snapshot({
     format_title("proper_title", 15)
     format_title("proper_title", 12)
     format_title("proper_title", 10)
-    format_title("proper_title", 10, footnote = FALSE)
     format_title("`a b`", 6)
     format_title("`a b`", 5)
     format_title("`a b`", 4)
-    format_title("`a b`", 4, footnote = FALSE)
     format_title("`a b`", 3)
+  })
+})
+
+test_that("title ticks and width", {
+  expect_snapshot({
+    format_title("proper_title", 15, footnote = FALSE)
+    format_title("proper_title", 12, footnote = FALSE)
+    format_title("proper_title", 10, footnote = FALSE)
+    format_title("`a b`", 6, footnote = FALSE)
+    format_title("`a b`", 5, footnote = FALSE)
+    format_title("`a b`", 4, footnote = FALSE)
+    format_title("`a b`", 3, footnote = FALSE)
     format_title("`a b`", 3, footnote = FALSE)
   })
 })


### PR DESCRIPTION
in footer.

The goal is to make all column names copy-pasteable and also get rid of `options(pillar.min_title_chars = )` .

``` r
palmerpenguins::penguins
#> # A tibble: 344 × 8
#>    species island    bill_length_mm bill_depth_mm flipper_length_mm body_mass_g
#>    <fct>   <fct>              <dbl>         <dbl>             <int>       <int>
#>  1 Adelie  Torgersen           39.1          18.7               181        3750
#>  2 Adelie  Torgersen           39.5          17.4               186        3800
#>  3 Adelie  Torgersen           40.3          18                 195        3250
#>  4 Adelie  Torgersen           NA            NA                  NA          NA
#>  5 Adelie  Torgersen           36.7          19.3               193        3450
#>  6 Adelie  Torgersen           39.3          20.6               190        3650
#>  7 Adelie  Torgersen           38.9          17.8               181        3625
#>  8 Adelie  Torgersen           39.2          19.6               195        4675
#>  9 Adelie  Torgersen           34.1          18.1               193        3475
#> 10 Adelie  Torgersen           42            20.2               190        4250
#> # … with 334 more rows, and 2 more variables: sex <fct>, year <int>

options(pillar.min_title_chars = 5)
palmerpenguins::penguins
#> # A tibble: 344 × 8
#>    species island    bill_length_mm bill_depth_mm flipper_le… body_… sex    year
#>    <fct>   <fct>              <dbl>         <dbl>       <int>  <int> <fct> <int>
#>  1 Adelie  Torgersen           39.1          18.7         181   3750 male   2007
#>  2 Adelie  Torgersen           39.5          17.4         186   3800 fema…  2007
#>  3 Adelie  Torgersen           40.3          18           195   3250 fema…  2007
#>  4 Adelie  Torgersen           NA            NA            NA     NA <NA>   2007
#>  5 Adelie  Torgersen           36.7          19.3         193   3450 fema…  2007
#>  6 Adelie  Torgersen           39.3          20.6         190   3650 male   2007
#>  7 Adelie  Torgersen           38.9          17.8         181   3625 fema…  2007
#>  8 Adelie  Torgersen           39.2          19.6         195   4675 male   2007
#>  9 Adelie  Torgersen           34.1          18.1         193   3475 <NA>   2007
#> 10 Adelie  Torgersen           42            20.2         190   4250 <NA>   2007
#> # … with 334 more rows, and abbreviated variable names flipper_length_mm,
#> #   body_mass_g
```

<sup>Created on 2022-01-30 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

The display is not perfect, we want to show all the data in the `sex` column. I have some ideas:

- let the data part decide how wide a column should be
- new `pillar.max_title_chars` option

Do we want to switch to bullet points in the footer?