### PR TITLE
Only data decides width of a pillar, with a minimum of 5

### DIFF
--- a/R/ctl_colonnade.R
+++ b/R/ctl_colonnade.R
@@ -419,11 +419,16 @@ do_emit_pillars <- function(x, tier_widths, cb, title = NULL, first_pillar = NUL
   }
 
   # We can proceed cautiously to the next level if space permits.
-  # For each sub-pillar we allow at most as much space so that
-  # we can print all first components of all remaining pillars
-  # with the minimum width
+  # First we decide for each pillar if it perhaps fits with its desired width.
+  max_widths <- map_int(pillar_list, pillar_get_width)
   min_widths <- map_int(pillar_list, pillar_get_min_width)
-  rev <- distribute_pillars_rev(min_widths, tier_widths)
+  pillar_pos <- colonnade_compute_tiered_col_widths_df(max_widths, min_widths, tier_widths)
+
+  # Based on this width, we compute, for each pillar, the maximum width
+  # that the other pillars before that pillar may consume.
+  # This allows pillars to stretch beyond their declared width (e.g. for
+  # compound pillars or for long column titles)
+  rev <- distribute_pillars_rev(pillar_pos$width, tier_widths)
   stopifnot(!anyNA(rev$tier))
 
   x_pos <- 0L

--- a/R/ctl_pillar.R
+++ b/R/ctl_pillar.R
@@ -187,7 +187,7 @@ format.pillar <- function(x, width = NULL, ...) {
   }
 
   if (is.null(width)) {
-    width <- pillar_get_width(x)
+    width <- pillar_get_ideal_width(x)
   }
 
   as_glue(pillar_format_parts_2(x, width)$aligned)

--- a/R/ctl_pillar_component.R
+++ b/R/ctl_pillar_component.R
@@ -60,12 +60,20 @@ pillar_component <- function(x) {
   new_pillar_component(list(x), width = get_width(x), min_width = get_min_width(x))
 }
 
+pillar_get_ideal_width <- function(x) {
+  max(MIN_PILLAR_WIDTH, as.integer(max(map_int(x, get_width))))
+}
+
 pillar_get_width <- function(x) {
-  as.integer(max(map_int(x, get_width)))
+  max(MIN_PILLAR_WIDTH, as.integer(
+    get_width(x[["data"]]) %||% max(map_int(x, get_width))
+  ))
 }
 
 pillar_get_min_width <- function(x) {
-  as.integer(max(map_int(x, get_min_width)))
+  max(MIN_PILLAR_WIDTH, as.integer(
+    get_min_width(x[["data"]]) %||% max(map_int(x, get_min_width))
+  ))
 }
 
 pillar_format_parts_2 <- function(x, width, is_focus = FALSE, footnote_idx = 1L) {

--- a/R/options.R
+++ b/R/options.R
@@ -103,13 +103,6 @@ pillar_options <- list2(
     }
     sigfig
   }),
-  #' - `min_title_chars`: The minimum number of characters for the column
-  #'     title, default: `15`.  Column titles may be truncated up to that width to
-  #'     save horizontal space. Set to `Inf` to turn off truncation of column
-  #'     titles.
-  min_title_chars = make_option_impl(
-    getOption("pillar.min_title_chars", default = 15L)
-  ),
   #' - `min_chars`: The minimum number of characters wide to
   #'     display character columns, default: `3`.  Character columns may be
   #'     truncated up to that width to save horizontal space. Set to `Inf` to

--- a/R/title.R
+++ b/R/title.R
@@ -28,26 +28,8 @@ new_pillar_title <- function(x, ...) {
   ret <- structure(list(x), class = "pillar_title")
 
   ret <- set_width(ret, width)
-  ret <- set_min_width(ret, get_min_title_width(width))
+  ret <- set_min_width(ret, MIN_PILLAR_WIDTH)
   ret
-}
-
-get_min_title_width <- function(width) {
-  title_chars <- get_pillar_option_min_title_chars()
-  if (!is.numeric(title_chars) || length(title_chars) != 1 || title_chars < 0) {
-    stop("Option pillar.min_title_chars must be a nonnegative number", call. = FALSE)
-  }
-
-  if (is.infinite(title_chars)) {
-    return(width)
-  }
-
-  # We don't use the ellipsis if we don't truncate, a solution with min()
-  # is difficult to make work in all corner cases (and slower too)
-  if (width <= title_chars) {
-    return(width)
-  }
-  title_chars + get_extent(get_ellipsis())
 }
 
 #' @export

--- a/man/pillar_options.Rd
+++ b/man/pillar_options.Rd
@@ -56,10 +56,6 @@ Default: \code{TRUE}.
 \item \code{sigfig}: The number of significant digits that will be printed and
 highlighted, default: \code{3}. Set the \code{subtle} option to \code{FALSE} to
 turn off highlighting of significant digits.
-\item \code{min_title_chars}: The minimum number of characters for the column
-title, default: \code{15}.  Column titles may be truncated up to that width to
-save horizontal space. Set to \code{Inf} to turn off truncation of column
-titles.
 \item \code{min_chars}: The minimum number of characters wide to
 display character columns, default: \code{3}.  Character columns may be
 truncated up to that width to save horizontal space. Set to \code{Inf} to

--- a/tests/testthat/_snaps/ansi/ctl_colonnade.md
+++ b/tests/testthat/_snaps/ansi/ctl_colonnade.md
@@ -301,10 +301,13 @@
       [90m# A data frame: 1 x
       #   2[39m
       [1m<tbl_format_body(setup)>[22m
-          a$x    $y b     
-        [4m[3m[90m<dbl>[39m[23m[24m [4m[3m[90m<dbl>[39m[23m[24m [4m[3m[90m<chr>[39m[23m[24m 
-      [90m1[39m     1     2 long ~
+          a$x b          
+        [4m[3m[90m<dbl>[39m[23m[24m [4m[3m[90m<chr>[39m[23m[24m      
+      [90m1[39m     1 long enough
       [1m<tbl_format_footer(setup)>[22m
+      [90m# ... with 1 more[39m
+      [90m#   variable:[39m
+      [90m#   a$y <dbl>[39m
     Code
       tbl_format_setup(x, width = 15, focus = c("a", "b"))
     Output

--- a/tests/testthat/_snaps/ctl_colonnade.md
+++ b/tests/testthat/_snaps/ctl_colonnade.md
@@ -71,21 +71,19 @@
       ctl_colonnade(trees[1:5, ], width = 20)
     Output
       $body
-        Girth Height
-        <dbl>  <dbl>
-      1   8.3     70
-      2   8.6     65
-      3   8.8     63
-      4  10.5     72
-      5  10.7     81
+        Girth Height Vol~1
+        <dbl>  <dbl> <dbl>
+      1   8.3     70  10.3
+      2   8.6     65  10.3
+      3   8.8     63  10.2
+      4  10.5     72  16.4
+      5  10.7     81  18.8
       
       $extra_cols
-      $extra_cols$Volume
-      [1] 10.3 10.3 10.2 16.4 18.8
-      
+      list()
       
       $abbrev_cols
-      character(0)
+      [1] "Volume"
       
     Code
       ctl_colonnade(trees[1:3, ], width = 10)

--- a/tests/testthat/_snaps/ctl_new_pillar.md
+++ b/tests/testthat/_snaps/ctl_new_pillar.md
@@ -46,10 +46,18 @@
            65
            63
       
+      [[3]]
+      <pillar>
+      $Volume
+        <dbl>
+         10.3
+         10.3
+         10.2
+      
       attr(,"extra")
-      [1] "Volume"
+      character(0)
       attr(,"remaining_width")
-      [1] 4
+      [1] 2
       attr(,"simple")
       [1] FALSE
     Code
@@ -63,10 +71,26 @@
               8.6
               8.8
       
+      [[2]]
+      <pillar>
+      [,"Height"]
+            <dbl>
+               70
+               65
+               63
+      
+      [[3]]
+      <pillar>
+      [,"Volume"]
+            <dbl>
+             10.3
+             10.3
+             10.2
+      
       attr(,"extra")
-      [1] 2 3
+      integer(0)
       attr(,"remaining_width")
-      [1] 8
+      [1] 2
       attr(,"simple")
       [1] FALSE
     Code

--- a/tests/testthat/_snaps/format_multi.md
+++ b/tests/testthat/_snaps/format_multi.md
@@ -116,11 +116,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_ze~1
-              <dbl>
-      1        1.23
-      2        2.23
-      3        3.23
+        col~1 col~1
+        <dbl> <chr>
+      1  1.23 a    
+      2  2.23 b    
+      3  3.23 c    
     Code
       colonnade(x, width = 14)
     Condition
@@ -128,11 +128,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zer~1
-               <dbl>
-      1         1.23
-      2         2.23
-      3         3.23
+        colu~1 col~1
+         <dbl> <chr>
+      1   1.23 a    
+      2   2.23 b    
+      3   3.23 c    
     Code
       colonnade(x, width = 15)
     Condition
@@ -140,11 +140,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero~1
-                <dbl>
-      1          1.23
-      2          2.23
-      3          3.23
+        colum~1 col~1
+          <dbl> <chr>
+      1    1.23 a    
+      2    2.23 b    
+      3    3.23 c    
     Code
       colonnade(x, width = 16)
     Condition
@@ -152,11 +152,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_~1
-                 <dbl>
-      1           1.23
-      2           2.23
-      3           3.23
+        column~1 col~1
+           <dbl> <chr>
+      1     1.23 a    
+      2     2.23 b    
+      3     3.23 c    
     Code
       colonnade(x, width = 17)
     Condition
@@ -164,11 +164,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one
-                  <dbl>
-      1            1.23
-      2            2.23
-      3            3.23
+        column_~1 col~1
+            <dbl> <chr>
+      1      1.23 a    
+      2      2.23 b    
+      3      3.23 c    
     Code
       colonnade(x, width = 18)
     Condition
@@ -176,11 +176,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one
-                  <dbl>
-      1            1.23
-      2            2.23
-      3            3.23
+        column_z~1 col~1
+             <dbl> <chr>
+      1       1.23 a    
+      2       2.23 b    
+      3       3.23 c    
     Code
       colonnade(x, width = 19)
     Condition
@@ -188,11 +188,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one
-                  <dbl>
-      1            1.23
-      2            2.23
-      3            3.23
+        col~1 col~1 col~1
+        <dbl> <chr> <fct>
+      1  1.23 a     a    
+      2  2.23 b     b    
+      3  3.23 c     c    
     Code
       colonnade(x, width = 20)
     Condition
@@ -200,11 +200,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one
-                  <dbl>
-      1            1.23
-      2            2.23
-      3            3.23
+        colu~1 col~1 col~1
+         <dbl> <chr> <fct>
+      1   1.23 a     a    
+      2   2.23 b     b    
+      3   3.23 c     c    
     Code
       colonnade(x, width = 21)
     Condition
@@ -212,11 +212,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one
-                  <dbl>
-      1            1.23
-      2            2.23
-      3            3.23
+        colum~1 col~1 col~1
+          <dbl> <chr> <fct>
+      1    1.23 a     a    
+      2    2.23 b     b    
+      3    3.23 c     c    
     Code
       colonnade(x, width = 22)
     Condition
@@ -224,11 +224,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one
-                  <dbl>
-      1            1.23
-      2            2.23
-      3            3.23
+        column~1 col~1 col~1
+           <dbl> <chr> <fct>
+      1     1.23 a     a    
+      2     2.23 b     b    
+      3     3.23 c     c    
     Code
       colonnade(x, width = 23)
     Condition
@@ -236,11 +236,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one
-                  <dbl>
-      1            1.23
-      2            2.23
-      3            3.23
+        column_~1 col~1 col~1
+            <dbl> <chr> <fct>
+      1      1.23 a     a    
+      2      2.23 b     b    
+      3      3.23 c     c    
     Code
       colonnade(x, width = 24)
     Condition
@@ -248,11 +248,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02
-                  <dbl> <chr> 
-      1            1.23 a     
-      2            2.23 b     
-      3            3.23 c     
+        column_z~1 col~1 col~1
+             <dbl> <chr> <fct>
+      1       1.23 a     a    
+      2       2.23 b     b    
+      3       3.23 c     c    
     Code
       colonnade(x, width = 25)
     Condition
@@ -260,11 +260,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02
-                  <dbl> <chr> 
-      1            1.23 a     
-      2            2.23 b     
-      3            3.23 c     
+        col~1 col~1 col~1 col~1
+        <dbl> <chr> <fct> <ord>
+      1  1.23 a     a     a    
+      2  2.23 b     b     b    
+      3  3.23 c     c     c    
     Code
       colonnade(x, width = 26)
     Condition
@@ -272,11 +272,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02
-                  <dbl> <chr> 
-      1            1.23 a     
-      2            2.23 b     
-      3            3.23 c     
+        colu~1 col~1 col~1 col~1
+         <dbl> <chr> <fct> <ord>
+      1   1.23 a     a     a    
+      2   2.23 b     b     b    
+      3   3.23 c     c     c    
     Code
       colonnade(x, width = 27)
     Condition
@@ -284,11 +284,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02
-                  <dbl> <chr> 
-      1            1.23 a     
-      2            2.23 b     
-      3            3.23 c     
+        colum~1 col~1 col~1 col~1
+          <dbl> <chr> <fct> <ord>
+      1    1.23 a     a     a    
+      2    2.23 b     b     b    
+      3    3.23 c     c     c    
     Code
       colonnade(x, width = 28)
     Condition
@@ -296,11 +296,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02
-                  <dbl> <chr> 
-      1            1.23 a     
-      2            2.23 b     
-      3            3.23 c     
+        column~1 col~1 col~1 col~1
+           <dbl> <chr> <fct> <ord>
+      1     1.23 a     a     a    
+      2     2.23 b     b     b    
+      3     3.23 c     c     c    
     Code
       colonnade(x, width = 29)
     Condition
@@ -308,11 +308,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02
-                  <dbl> <chr> 
-      1            1.23 a     
-      2            2.23 b     
-      3            3.23 c     
+        column_~1 col~1 col~1 col~1
+            <dbl> <chr> <fct> <ord>
+      1      1.23 a     a     a    
+      2      2.23 b     b     b    
+      3      3.23 c     c     c    
     Code
       colonnade(x, width = 30)
     Condition
@@ -320,11 +320,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02
-                  <dbl> <chr> 
-      1            1.23 a     
-      2            2.23 b     
-      3            3.23 c     
+        column_~1 col_02 col~1 col~1
+            <dbl> <chr>  <fct> <ord>
+      1      1.23 a      a     a    
+      2      2.23 b      b     b    
+      3      3.23 c      c     c    
     Code
       colonnade(x, width = 31)
     Condition
@@ -332,11 +332,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02 col_03
-                  <dbl> <chr>  <fct> 
-      1            1.23 a      a     
-      2            2.23 b      b     
-      3            3.23 c      c     
+        column_z~1 col_02 col~1 col~1
+             <dbl> <chr>  <fct> <ord>
+      1       1.23 a      a     a    
+      2       2.23 b      b     b    
+      3       3.23 c      c     c    
     Code
       colonnade(x, width = 32)
     Condition
@@ -344,11 +344,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02 col_03
-                  <dbl> <chr>  <fct> 
-      1            1.23 a      a     
-      2            2.23 b      b     
-      3            3.23 c      c     
+        column_ze~1 col_02 col~1 col~1
+              <dbl> <chr>  <fct> <ord>
+      1        1.23 a      a     a    
+      2        2.23 b      b     b    
+      3        3.23 c      c     c    
     Code
       colonnade(x, width = 33)
     Condition
@@ -356,11 +356,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02 col_03
-                  <dbl> <chr>  <fct> 
-      1            1.23 a      a     
-      2            2.23 b      b     
-      3            3.23 c      c     
+        column_zer~1 col_02 col~1 col~1
+               <dbl> <chr>  <fct> <ord>
+      1         1.23 a      a     a    
+      2         2.23 b      b     b    
+      3         3.23 c      c     c    
     Code
       colonnade(x, width = 34)
     Condition
@@ -368,11 +368,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02 col_03
-                  <dbl> <chr>  <fct> 
-      1            1.23 a      a     
-      2            2.23 b      b     
-      3            3.23 c      c     
+        column_zer~1 col_02 col_03 col~1
+               <dbl> <chr>  <fct>  <ord>
+      1         1.23 a      a      a    
+      2         2.23 b      b      b    
+      3         3.23 c      c      c    
     Code
       colonnade(x, width = 35)
     Condition
@@ -380,11 +380,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02 col_03
-                  <dbl> <chr>  <fct> 
-      1            1.23 a      a     
-      2            2.23 b      b     
-      3            3.23 c      c     
+        column_zero_one col~1 col~1 col~1
+                  <dbl> <chr> <fct> <ord>
+      1            1.23 a     a     a    
+      2            2.23 b     b     b    
+      3            3.23 c     c     c    
     Code
       colonnade(x, width = 36)
     Condition
@@ -392,11 +392,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02 col_03
-                  <dbl> <chr>  <fct> 
-      1            1.23 a      a     
-      2            2.23 b      b     
-      3            3.23 c      c     
+        column_zero_one col_02 col~1 col~1
+                  <dbl> <chr>  <fct> <ord>
+      1            1.23 a      a     a    
+      2            2.23 b      b     b    
+      3            3.23 c      c     c    
     Code
       colonnade(x, width = 37)
     Condition
@@ -404,11 +404,11 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        column_zero_one col_02 col_03
-                  <dbl> <chr>  <fct> 
-      1            1.23 a      a     
-      2            2.23 b      b     
-      3            3.23 c      c     
+        column_zero_one col_02 col_03 col~1
+                  <dbl> <chr>  <fct>  <ord>
+      1            1.23 a      a      a    
+      2            2.23 b      b      b    
+      3            3.23 c      c      c    
     Code
       colonnade(x, width = 38)
     Condition
@@ -486,8 +486,6 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-      col_02 <chr>
-      col_03 <fct>
       col_04 <ord>
 
 ---
@@ -498,9 +496,6 @@
       Warning:
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
-    Output
-      col_03 <fct>
-      col_04 <ord>
 
 ---
 
@@ -510,8 +505,6 @@
       Warning:
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
-    Output
-      col_04 <ord>
 
 ---
 
@@ -548,13 +541,13 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        Girth Height
-        <dbl>  <dbl>
-      1   8.3     70
-      2   8.6     65
-      3   8.8     63
-      4  10.5     72
-      5  10.7     81
+        Girth Height Vol~1
+        <dbl>  <dbl> <dbl>
+      1   8.3     70  10.3
+      2   8.6     65  10.3
+      3   8.8     63  10.2
+      4  10.5     72  16.4
+      5  10.7     81  18.8
     Code
       colonnade(trees[1:3, ], width = 10)
     Condition

--- a/tests/testthat/_snaps/tbl-format-footer.md
+++ b/tests/testthat/_snaps/tbl-format-footer.md
@@ -61,24 +61,24 @@
       tbl_format_footer(tbl_format_setup(new_footer_tbl("prefix_")))
     Output
       <tbl_format_footer(setup)>
-      # ... with 45 more variables: prefix_bd <int>, prefix_ae <int>,
-      #   prefix_be <int>, prefix_af <int>, prefix_bf <int>, prefix_ag <int>,
-      #   prefix_bg <int>, prefix_ah <int>, prefix_bh <int>, prefix_ai <int>,
-      #   prefix_bi <int>, prefix_aj <int>, prefix_bj <int>, prefix_ak <int>,
-      #   prefix_bk <int>, prefix_al <int>, prefix_bl <int>, prefix_am <int>,
-      #   prefix_bm <int>, prefix_an <int>, prefix_bn <int>, prefix_ao <int>,
-      #   prefix_bo <int>, prefix_ap <int>, prefix_bp <int>, prefix_aq <int>, ...
+      # ... with abbreviated variable names 1: prefix_aa, 2: prefix_ba, 3: prefix_ab,
+      #   4: prefix_bb, 5: prefix_ac, 6: prefix_bc, 7: prefix_ad, 8: prefix_bd,
+      #   9: prefix_ae, *: prefix_be, *: prefix_af, *: prefix_bf, *: prefix_ag, and
+      #   39 more variables: prefix_bg <int>, prefix_ah <int>, prefix_bh <int>,
+      #   prefix_ai <int>, prefix_bi <int>, prefix_aj <int>, prefix_bj <int>,
+      #   prefix_ak <int>, prefix_bk <int>, prefix_al <int>, prefix_bl <int>,
+      #   prefix_am <int>, prefix_bm <int>, prefix_an <int>, prefix_bn <int>, ...
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl("a_very_long_prefix_")))
     Output
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable names 1: a_very_long_prefix_ab,
-      #   2: a_very_long_prefix_bb, and 48 more variables:
-      #   a_very_long_prefix_ac <int>, a_very_long_prefix_bc <int>,
-      #   a_very_long_prefix_ad <int>, a_very_long_prefix_bd <int>,
-      #   a_very_long_prefix_ae <int>, a_very_long_prefix_be <int>,
-      #   a_very_long_prefix_af <int>, a_very_long_prefix_bf <int>,
-      #   a_very_long_prefix_ag <int>, a_very_long_prefix_bg <int>, ...
+      # ... with abbreviated variable names 1: a_very_long_prefix_aa,
+      #   2: a_very_long_prefix_ba, 3: a_very_long_prefix_ab,
+      #   4: a_very_long_prefix_bb, 5: a_very_long_prefix_ac,
+      #   6: a_very_long_prefix_bc, 7: a_very_long_prefix_ad,
+      #   8: a_very_long_prefix_bd, 9: a_very_long_prefix_ae,
+      #   *: a_very_long_prefix_be, *: a_very_long_prefix_af,
+      #   *: a_very_long_prefix_bf, *: a_very_long_prefix_ag, and 39 more ...
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl(""), max_footer_lines = 3))
     Output
@@ -90,17 +90,17 @@
       tbl_format_footer(tbl_format_setup(new_footer_tbl("prefix_"), max_footer_lines = 3))
     Output
       <tbl_format_footer(setup)>
-      # ... with 45 more variables: prefix_bd <int>, prefix_ae <int>,
-      #   prefix_be <int>, prefix_af <int>, prefix_bf <int>, prefix_ag <int>,
-      #   prefix_bg <int>, prefix_ah <int>, prefix_bh <int>, prefix_ai <int>, ...
+      # ... with abbreviated variable names 1: prefix_aa, 2: prefix_ba, 3: prefix_ab,
+      #   4: prefix_bb, 5: prefix_ac, 6: prefix_bc, 7: prefix_ad, 8: prefix_bd,
+      #   9: prefix_ae, *: prefix_be, *: prefix_af, *: prefix_bf, *: prefix_ag, ...
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl("a_very_long_prefix_"),
       max_footer_lines = 3))
     Output
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable names 1: a_very_long_prefix_ab,
-      #   2: a_very_long_prefix_bb, and 48 more variables:
-      #   a_very_long_prefix_ac <int>, a_very_long_prefix_bc <int>, ...
+      # ... with abbreviated variable names 1: a_very_long_prefix_aa,
+      #   2: a_very_long_prefix_ba, 3: a_very_long_prefix_ab,
+      #   4: a_very_long_prefix_bb, 5: a_very_long_prefix_ac, ...
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl(""), max_footer_lines = Inf))
     Output
@@ -115,47 +115,49 @@
       tbl_format_footer(tbl_format_setup(new_footer_tbl("prefix_"), max_footer_lines = Inf))
     Output
       <tbl_format_footer(setup)>
-      # ... with 45 more variables: prefix_bd <int>, prefix_ae <int>,
-      #   prefix_be <int>, prefix_af <int>, prefix_bf <int>, prefix_ag <int>,
-      #   prefix_bg <int>, prefix_ah <int>, prefix_bh <int>, prefix_ai <int>,
-      #   prefix_bi <int>, prefix_aj <int>, prefix_bj <int>, prefix_ak <int>,
-      #   prefix_bk <int>, prefix_al <int>, prefix_bl <int>, prefix_am <int>,
-      #   prefix_bm <int>, prefix_an <int>, prefix_bn <int>, prefix_ao <int>,
-      #   prefix_bo <int>, prefix_ap <int>, prefix_bp <int>, prefix_aq <int>,
-      #   prefix_bq <int>, prefix_ar <int>, prefix_br <int>, prefix_as <int>,
-      #   prefix_bs <int>, prefix_at <int>, prefix_bt <int>, prefix_au <int>,
-      #   prefix_bu <int>, prefix_av <int>, prefix_bv <int>, prefix_aw <int>,
-      #   prefix_bw <int>, prefix_ax <int>, prefix_bx <int>, prefix_ay <int>,
-      #   prefix_by <int>, prefix_az <int>, prefix_bz <int>
+      # ... with abbreviated variable names 1: prefix_aa, 2: prefix_ba, 3: prefix_ab,
+      #   4: prefix_bb, 5: prefix_ac, 6: prefix_bc, 7: prefix_ad, 8: prefix_bd,
+      #   9: prefix_ae, *: prefix_be, *: prefix_af, *: prefix_bf, *: prefix_ag, and
+      #   39 more variables: prefix_bg <int>, prefix_ah <int>, prefix_bh <int>,
+      #   prefix_ai <int>, prefix_bi <int>, prefix_aj <int>, prefix_bj <int>,
+      #   prefix_ak <int>, prefix_bk <int>, prefix_al <int>, prefix_bl <int>,
+      #   prefix_am <int>, prefix_bm <int>, prefix_an <int>, prefix_bn <int>,
+      #   prefix_ao <int>, prefix_bo <int>, prefix_ap <int>, prefix_bp <int>,
+      #   prefix_aq <int>, prefix_bq <int>, prefix_ar <int>, prefix_br <int>,
+      #   prefix_as <int>, prefix_bs <int>, prefix_at <int>, prefix_bt <int>,
+      #   prefix_au <int>, prefix_bu <int>, prefix_av <int>, prefix_bv <int>,
+      #   prefix_aw <int>, prefix_bw <int>, prefix_ax <int>, prefix_bx <int>,
+      #   prefix_ay <int>, prefix_by <int>, prefix_az <int>, prefix_bz <int>
     Code
       tbl_format_footer(tbl_format_setup(new_footer_tbl("a_very_long_prefix_"),
       max_footer_lines = Inf))
     Output
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable names 1: a_very_long_prefix_ab,
-      #   2: a_very_long_prefix_bb, and 48 more variables:
-      #   a_very_long_prefix_ac <int>, a_very_long_prefix_bc <int>,
-      #   a_very_long_prefix_ad <int>, a_very_long_prefix_bd <int>,
-      #   a_very_long_prefix_ae <int>, a_very_long_prefix_be <int>,
-      #   a_very_long_prefix_af <int>, a_very_long_prefix_bf <int>,
-      #   a_very_long_prefix_ag <int>, a_very_long_prefix_bg <int>,
-      #   a_very_long_prefix_ah <int>, a_very_long_prefix_bh <int>,
-      #   a_very_long_prefix_ai <int>, a_very_long_prefix_bi <int>,
-      #   a_very_long_prefix_aj <int>, a_very_long_prefix_bj <int>,
-      #   a_very_long_prefix_ak <int>, a_very_long_prefix_bk <int>,
-      #   a_very_long_prefix_al <int>, a_very_long_prefix_bl <int>,
-      #   a_very_long_prefix_am <int>, a_very_long_prefix_bm <int>,
-      #   a_very_long_prefix_an <int>, a_very_long_prefix_bn <int>,
-      #   a_very_long_prefix_ao <int>, a_very_long_prefix_bo <int>,
-      #   a_very_long_prefix_ap <int>, a_very_long_prefix_bp <int>,
-      #   a_very_long_prefix_aq <int>, a_very_long_prefix_bq <int>,
-      #   a_very_long_prefix_ar <int>, a_very_long_prefix_br <int>,
-      #   a_very_long_prefix_as <int>, a_very_long_prefix_bs <int>,
-      #   a_very_long_prefix_at <int>, a_very_long_prefix_bt <int>,
-      #   a_very_long_prefix_au <int>, a_very_long_prefix_bu <int>,
-      #   a_very_long_prefix_av <int>, a_very_long_prefix_bv <int>,
-      #   a_very_long_prefix_aw <int>, a_very_long_prefix_bw <int>,
-      #   a_very_long_prefix_ax <int>, a_very_long_prefix_bx <int>,
-      #   a_very_long_prefix_ay <int>, a_very_long_prefix_by <int>,
-      #   a_very_long_prefix_az <int>, a_very_long_prefix_bz <int>
+      # ... with abbreviated variable names 1: a_very_long_prefix_aa,
+      #   2: a_very_long_prefix_ba, 3: a_very_long_prefix_ab,
+      #   4: a_very_long_prefix_bb, 5: a_very_long_prefix_ac,
+      #   6: a_very_long_prefix_bc, 7: a_very_long_prefix_ad,
+      #   8: a_very_long_prefix_bd, 9: a_very_long_prefix_ae,
+      #   *: a_very_long_prefix_be, *: a_very_long_prefix_af,
+      #   *: a_very_long_prefix_bf, *: a_very_long_prefix_ag, and 39 more variables:
+      #   a_very_long_prefix_bg <int>, a_very_long_prefix_ah <int>,
+      #   a_very_long_prefix_bh <int>, a_very_long_prefix_ai <int>,
+      #   a_very_long_prefix_bi <int>, a_very_long_prefix_aj <int>,
+      #   a_very_long_prefix_bj <int>, a_very_long_prefix_ak <int>,
+      #   a_very_long_prefix_bk <int>, a_very_long_prefix_al <int>,
+      #   a_very_long_prefix_bl <int>, a_very_long_prefix_am <int>,
+      #   a_very_long_prefix_bm <int>, a_very_long_prefix_an <int>,
+      #   a_very_long_prefix_bn <int>, a_very_long_prefix_ao <int>,
+      #   a_very_long_prefix_bo <int>, a_very_long_prefix_ap <int>,
+      #   a_very_long_prefix_bp <int>, a_very_long_prefix_aq <int>,
+      #   a_very_long_prefix_bq <int>, a_very_long_prefix_ar <int>,
+      #   a_very_long_prefix_br <int>, a_very_long_prefix_as <int>,
+      #   a_very_long_prefix_bs <int>, a_very_long_prefix_at <int>,
+      #   a_very_long_prefix_bt <int>, a_very_long_prefix_au <int>,
+      #   a_very_long_prefix_bu <int>, a_very_long_prefix_av <int>,
+      #   a_very_long_prefix_bv <int>, a_very_long_prefix_aw <int>,
+      #   a_very_long_prefix_bw <int>, a_very_long_prefix_ax <int>,
+      #   a_very_long_prefix_bx <int>, a_very_long_prefix_ay <int>,
+      #   a_very_long_prefix_by <int>, a_very_long_prefix_az <int>,
+      #   a_very_long_prefix_bz <int>
 

--- a/tests/testthat/_snaps/tbl-format-setup.md
+++ b/tests/testthat/_snaps/tbl-format-setup.md
@@ -65,13 +65,18 @@
       #   x
       #   3
       <tbl_format_body(setup)>
+        col~1
+        <dbl>
+      1  1.23
+      2  2.23
+      3  3.23
       <tbl_format_footer(setup)>
       #   with
-      #   3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>, ...
+      #   abbreviated
+      #   variable
+      #   name
+      #   1: column_zero_zero,
+      #   and ...
     Code
       tbl_format_setup(x, width = 8)
     Output
@@ -83,13 +88,18 @@
       #   3 x
       #   3
       <tbl_format_body(setup)>
+        colu~1
+         <dbl>
+      1   1.23
+      2   2.23
+      3   3.23
       <tbl_format_footer(setup)>
       #   with
-      #   3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>, ...
+      #   abbreviated
+      #   variable
+      #   name
+      #   1: column_zero_zero,
+      #   and ...
     Code
       tbl_format_setup(x, width = 9)
     Output
@@ -100,13 +110,18 @@
       #   3 x
       #   3
       <tbl_format_body(setup)>
+        colum~1
+          <dbl>
+      1    1.23
+      2    2.23
+      3    3.23
       <tbl_format_footer(setup)>
       #   with
-      #   3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>, ...
+      #   abbreviated
+      #   variable
+      #   name
+      #   1: column_zero_zero,
+      #   and ...
     Code
       tbl_format_setup(x, width = 10)
     Output
@@ -116,13 +131,18 @@
       #   frame:
       #   3 x 3
       <tbl_format_body(setup)>
+        column~1
+           <dbl>
+      1     1.23
+      2     2.23
+      3     3.23
       <tbl_format_footer(setup)>
       #   with
-      #   3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>, ...
+      #   abbreviated
+      #   variable
+      #   name
+      #   1: column_zero_zero,
+      #   and ...
     Code
       tbl_format_setup(x, width = 11)
     Output
@@ -132,13 +152,19 @@
       #   frame:
       #   3 x 3
       <tbl_format_body(setup)>
+        column_~1
+            <dbl>
+      1      1.23
+      2      2.23
+      3      3.23
       <tbl_format_footer(setup)>
       # ... with
-      #   3 more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      #   abbreviated
+      #   variable
+      #   name
+      #   1: column_zero_zero,
+      #   and 2
+      #   more ...
     Code
       tbl_format_setup(x, width = 12)
     Output
@@ -148,13 +174,19 @@
       #   frame:
       #   3 x 3
       <tbl_format_body(setup)>
+        column_z~1
+             <dbl>
+      1       1.23
+      2       2.23
+      3       3.23
       <tbl_format_footer(setup)>
       # ... with
-      #   3 more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      #   abbreviated
+      #   variable
+      #   name
+      #   1: column_zero_zero,
+      #   and 2
+      #   more ...
     Code
       tbl_format_setup(x, width = 13)
     Output
@@ -164,13 +196,19 @@
       #   frame: 3
       #   x 3
       <tbl_format_body(setup)>
+        col~1 col~2
+        <dbl> <chr>
+      1  1.23 a    
+      2  2.23 b    
+      3  3.23 c    
       <tbl_format_footer(setup)>
-      # ... with 3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable
+      #   names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   and ...
     Code
       tbl_format_setup(x, width = 14)
     Output
@@ -180,13 +218,19 @@
       #   frame: 3
       #   x 3
       <tbl_format_body(setup)>
+        colu~1 col~2
+         <dbl> <chr>
+      1   1.23 a    
+      2   2.23 b    
+      3   3.23 c    
       <tbl_format_footer(setup)>
-      # ... with 3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable
+      #   names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   and 3 ...
     Code
       tbl_format_setup(x, width = 15)
     Output
@@ -196,13 +240,19 @@
       #   frame: 3 x
       #   3
       <tbl_format_body(setup)>
+        colum~1 col~2
+          <dbl> <chr>
+      1    1.23 a    
+      2    2.23 b    
+      3    3.23 c    
       <tbl_format_footer(setup)>
-      # ... with 3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable
+      #   names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   and 3 ...
     Code
       tbl_format_setup(x, width = 16)
     Output
@@ -211,13 +261,19 @@
       # A data frame:
       #   3 x 3
       <tbl_format_body(setup)>
+        column~1 col~2
+           <dbl> <chr>
+      1     1.23 a    
+      2     2.23 b    
+      3     3.23 c    
       <tbl_format_footer(setup)>
-      # ... with 3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable
+      #   names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   and 3 ...
     Code
       tbl_format_setup(x, width = 17)
     Output
@@ -226,13 +282,19 @@
       # A data frame:
       #   3 x 3
       <tbl_format_body(setup)>
+        column_~1 col~2
+            <dbl> <chr>
+      1      1.23 a    
+      2      2.23 b    
+      3      3.23 c    
       <tbl_format_footer(setup)>
-      # ... with 3
-      #   more
-      #   variables:
-      #   column_zero_zero <dbl>,
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable
+      #   names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   and 3 ...
     Code
       tbl_format_setup(x, width = 18)
     Output
@@ -241,16 +303,19 @@
       # A data frame: 3
       #   x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_z~1 col~2
+             <dbl> <chr>
+      1       1.23 a    
+      2       2.23 b    
+      3       3.23 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable
+      #   names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   and 3 ...
     Code
       tbl_format_setup(x, width = 19)
     Output
@@ -259,16 +324,19 @@
       # A data frame: 3
       #   x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        col~1 col~2 col~3
+        <dbl> <chr> <ord>
+      1  1.23 a     a    
+      2  2.23 b     b    
+      3  3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`,
+      #   and 2 more ...
     Code
       tbl_format_setup(x, width = 20)
     Output
@@ -277,16 +345,19 @@
       # A data frame: 3 x
       #   3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        colu~1 col~2 col~3
+         <dbl> <chr> <ord>
+      1   1.23 a     a    
+      2   2.23 b     b    
+      3   3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`,
+      #   and 2 more ...
     Code
       tbl_format_setup(x, width = 21)
     Output
@@ -295,16 +366,19 @@
       # A data frame: 3 x
       #   3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        colum~1 col~2 col~3
+          <dbl> <chr> <ord>
+      1    1.23 a     a    
+      2    2.23 b     b    
+      3    3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and
+      #   2 more ...
     Code
       tbl_format_setup(x, width = 22)
     Output
@@ -312,16 +386,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column~1 col~2 col~3
+           <dbl> <chr> <ord>
+      1     1.23 a     a    
+      2     2.23 b     b    
+      3     3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with
+      #   abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and
+      #   2 more ...
     Code
       tbl_format_setup(x, width = 23)
     Output
@@ -329,16 +406,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_~1 col~2 col~3
+            <dbl> <chr> <ord>
+      1      1.23 a     a    
+      2      2.23 b     b    
+      3      3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and 2
+      #   more variables:
+      #   `col 01`$`col 03` <chr>, ...
     Code
       tbl_format_setup(x, width = 24)
     Output
@@ -346,16 +426,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_z~1 col~2 col~3
+             <dbl> <chr> <ord>
+      1       1.23 a     a    
+      2       2.23 b     b    
+      3       3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and 2
+      #   more variables:
+      #   `col 01`$`col 03` <chr>, ...
     Code
       tbl_format_setup(x, width = 25)
     Output
@@ -363,16 +446,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_ze~1 col~2 col~3
+              <dbl> <chr> <ord>
+      1        1.23 a     a    
+      2        2.23 b     b    
+      3        3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and 2
+      #   more variables:
+      #   `col 01`$`col 03` <chr>, ...
     Code
       tbl_format_setup(x, width = 26)
     Output
@@ -380,16 +466,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zer~1 col~2 col~3
+               <dbl> <chr> <ord>
+      1         1.23 a     a    
+      2         2.23 b     b    
+      3         3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and 2
+      #   more variables:
+      #   `col 01`$`col 03` <chr>, ...
     Code
       tbl_format_setup(x, width = 27)
     Output
@@ -397,16 +486,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zero~1 col~2 col~3
+                <dbl> <chr> <ord>
+      1          1.23 a     a    
+      2          2.23 b     b    
+      3          3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
-      #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and 2
+      #   more variables:
+      #   `col 01`$`col 03` <chr>, ...
     Code
       tbl_format_setup(x, width = 28)
     Output
@@ -414,16 +506,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zero_~1 col~2 col~3
+                 <dbl> <chr> <ord>
+      1           1.23 a     a    
+      2           2.23 b     b    
+      3           3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more
+      # ... with abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and 2 more
       #   variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      #   `col 01`$`col 03` <chr>, ...
     Code
       tbl_format_setup(x, width = 29)
     Output
@@ -431,15 +526,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zero_z~1 col~2 col~3
+                  <dbl> <chr> <ord>
+      1            1.23 a     a    
+      2            2.23 b     b    
+      3            3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated
+      #   variable names
+      #   1: column_zero_zero,
+      #   2: `col 01`$`col 02`,
+      #   3: `col 05`, and 2 more
+      #   variables:
+      #   `col 01`$`col 03` <chr>, ...
     Code
       tbl_format_setup(x, width = 30)
     Output
@@ -447,15 +546,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zero_zero col~1 col~2
+                   <dbl> <chr> <ord>
+      1             1.23 a     a    
+      2             2.23 b     b    
+      3             3.23 c     c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated
+      #   variable names
+      #   1: `col 01`$`col 02`,
+      #   2: `col 05`, and 2 more
+      #   variables:
+      #   `col 01`$`col 03` <chr>,
+      #   $`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 31)
     Output
@@ -463,15 +566,19 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zero_zero col ~1 col~2
+                   <dbl> <chr>  <ord>
+      1             1.23 a      a    
+      2             2.23 b      b    
+      3             3.23 c      c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated
+      #   variable names
+      #   1: `col 01`$`col 02`,
+      #   2: `col 05`, and 2 more
+      #   variables:
+      #   `col 01`$`col 03` <chr>,
+      #   $`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 32)
     Output
@@ -479,15 +586,18 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zero_zero col 0~1 col~2
+                   <dbl> <chr>   <ord>
+      1             1.23 a       a    
+      2             2.23 b       b    
+      3             3.23 c       c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated variable
+      #   names 1: `col 01`$`col 02`,
+      #   2: `col 05`, and 2 more
+      #   variables:
+      #   `col 01`$`col 03` <chr>,
+      #   $`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 33)
     Output
@@ -495,15 +605,18 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zero_zero col 01~1 col~2
+                   <dbl> <chr>    <ord>
+      1             1.23 a        a    
+      2             2.23 b        b    
+      3             3.23 c        c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated variable
+      #   names 1: `col 01`$`col 02`,
+      #   2: `col 05`, and 2 more
+      #   variables:
+      #   `col 01`$`col 03` <chr>,
+      #   $`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 34)
     Output
@@ -511,15 +624,18 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero
-                   <dbl>
-      1             1.23
-      2             2.23
-      3             3.23
+        column_zero_zero col 01$~1 col~2
+                   <dbl> <chr>     <ord>
+      1             1.23 a         a    
+      2             2.23 b         b    
+      3             3.23 c         c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01` <tbl[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated variable
+      #   names 1: `col 01`$`col 02`,
+      #   2: `col 05`, and 2 more
+      #   variables:
+      #   `col 01`$`col 03` <chr>,
+      #   $`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 35)
     Output
@@ -527,18 +643,18 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero col 01$col 02~1
-                   <dbl> <chr>          
-      1             1.23 a              
-      2             2.23 b              
-      3             3.23 c              
+        column_zero_zero col 01$c~1 col~2
+                   <dbl> <chr>      <ord>
+      1             1.23 a          a    
+      2             2.23 b          b    
+      3             3.23 c          c    
       <tbl_format_footer(setup)>
       # ... with abbreviated variable
-      #   name 1: `col 01`$`col 02`, and
-      #   3 more variables:
+      #   names 1: `col 01`$`col 02`,
+      #   2: `col 05`, and 2 more
+      #   variables:
       #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>,
-      #   `col 05` <ord>
+      #   $`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 36)
     Output
@@ -546,16 +662,17 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02`
-                   <dbl> <chr>            
-      1             1.23 a                
-      2             2.23 b                
-      3             3.23 c                
+        column_zero_zero col~1 $co~2 col~3
+                   <dbl> <chr> <chr> <ord>
+      1             1.23 a     A     a    
+      2             2.23 b     B     b    
+      3             3.23 c     C     c    
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated variable
+      #   names 1: `col 01`$`col 02`,
+      #   2: $`col 03`, 3: `col 05`, and
+      #   1 more variable:
+      #   `col 01`$`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 37)
     Output
@@ -563,16 +680,17 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02`
-                   <dbl> <chr>            
-      1             1.23 a                
-      2             2.23 b                
-      3             3.23 c                
+        column_zero_zero col ~1 $co~2 col~3
+                   <dbl> <chr>  <chr> <ord>
+      1             1.23 a      A     a    
+      2             2.23 b      B     b    
+      3             3.23 c      C     c    
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated variable
+      #   names 1: `col 01`$`col 02`,
+      #   2: $`col 03`, 3: `col 05`, and 1
+      #   more variable:
+      #   `col 01`$`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 38)
     Output
@@ -580,16 +698,17 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02`
-                   <dbl> <chr>            
-      1             1.23 a                
-      2             2.23 b                
-      3             3.23 c                
+        column_zero_zero col 0~1 $co~2 col~3
+                   <dbl> <chr>   <chr> <ord>
+      1             1.23 a       A     a    
+      2             2.23 b       B     b    
+      3             3.23 c       C     c    
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`,
+      #   2: $`col 03`, 3: `col 05`, and 1
+      #   more variable:
+      #   `col 01`$`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 39)
     Output
@@ -597,16 +716,17 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02`
-                   <dbl> <chr>            
-      1             1.23 a                
-      2             2.23 b                
-      3             3.23 c                
+        column_zero_zero col 01~1 $co~2 col~3
+                   <dbl> <chr>    <chr> <ord>
+      1             1.23 a        A     a    
+      2             2.23 b        B     b    
+      3             3.23 c        C     c    
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>,
-      #   `col 05` <ord>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`,
+      #   2: $`col 03`, 3: `col 05`, and 1
+      #   more variable:
+      #   `col 01`$`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 40)
     Output
@@ -614,15 +734,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02`
-                   <dbl> <chr>            
-      1             1.23 a                
-      2             2.23 b                
-      3             3.23 c                
+        column_zero_zero col 01$~1 $co~2 col~3
+                   <dbl> <chr>     <chr> <ord>
+      1             1.23 a         A     a    
+      2             2.23 b         B     b    
+      3             3.23 c         C     c    
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>, `col 05` <ord>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 41)
     Output
@@ -630,15 +751,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02`
-                   <dbl> <chr>            
-      1             1.23 a                
-      2             2.23 b                
-      3             3.23 c                
+        column_zero_zero col 01$c~1 $co~2 col~3
+                   <dbl> <chr>      <chr> <ord>
+      1             1.23 a          A     a    
+      2             2.23 b          B     b    
+      3             3.23 c          C     c    
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>, `col 05` <ord>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04` <int[,3]>
     Code
       tbl_format_setup(x, width = 42)
     Output
@@ -646,15 +768,17 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02`
-                   <dbl> <chr>            
-      1             1.23 a                
-      2             2.23 b                
-      3             3.23 c                
+        column_zero_zero col~1 $co~2 $co~3 col~4
+                   <dbl> <chr> <chr> <int> <ord>
+      1             1.23 a     A         1 a    
+      2             2.23 b     B         2 b    
+      3             3.23 c     C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>, `col 05` <ord>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable:
+      #   `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 43)
     Output
@@ -662,15 +786,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02`
-                   <dbl> <chr>            
-      1             1.23 a                
-      2             2.23 b                
-      3             3.23 c                
+        column_zero_zero col ~1 $co~2 $co~3 col~4
+                   <dbl> <chr>  <chr> <int> <ord>
+      1             1.23 a      A         1 a    
+      2             2.23 b      B         2 b    
+      3             3.23 c      C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 3 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>, `col 05` <ord>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 44)
     Output
@@ -678,16 +803,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero col 01$col 02~1 `col 05`
-                   <dbl> <chr>           <ord>   
-      1             1.23 a               a       
-      2             2.23 b               b       
-      3             3.23 c               c       
+        column_zero_zero col 0~1 $co~2 $co~3 col~4
+                   <dbl> <chr>   <chr> <int> <ord>
+      1             1.23 a       A         1 a    
+      2             2.23 b       B         2 b    
+      3             3.23 c       C         3 c    
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable name
-      #   1: `col 01`$`col 02`, and 2 more
-      #   variables: `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 45)
     Output
@@ -695,15 +820,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01~1 $co~2 $co~3 col~4
+                   <dbl> <chr>    <chr> <int> <ord>
+      1             1.23 a        A         1 a    
+      2             2.23 b        B         2 b    
+      3             3.23 c        C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 46)
     Output
@@ -711,15 +837,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01$~1 $co~2 $co~3 col~4
+                   <dbl> <chr>     <chr> <int> <ord>
+      1             1.23 a         A         1 a    
+      2             2.23 b         B         2 b    
+      3             3.23 c         C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 47)
     Output
@@ -727,15 +854,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01$c~1 $co~2 $co~3 col~4
+                   <dbl> <chr>      <chr> <int> <ord>
+      1             1.23 a          A         1 a    
+      2             2.23 b          B         2 b    
+      3             3.23 c          C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 48)
     Output
@@ -743,15 +871,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01$co~1 $co~2 $co~3 col~4
+                   <dbl> <chr>       <chr> <int> <ord>
+      1             1.23 a           A         1 a    
+      2             2.23 b           B         2 b    
+      3             3.23 c           C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>,
-      #   $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 49)
     Output
@@ -759,14 +888,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01$col~1 $co~2 $co~3 col~4
+                   <dbl> <chr>        <chr> <int> <ord>
+      1             1.23 a            A         1 a    
+      2             2.23 b            B         2 b    
+      3             3.23 c            C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>, $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 50)
     Output
@@ -774,14 +905,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01$col ~1 $co~2 $co~3 col~4
+                   <dbl> <chr>         <chr> <int> <ord>
+      1             1.23 a             A         1 a    
+      2             2.23 b             B         2 b    
+      3             3.23 c             C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>, $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 51)
     Output
@@ -789,14 +922,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01$col 0~1 $co~2 $co~3 col~4
+                   <dbl> <chr>          <chr> <int> <ord>
+      1             1.23 a              A         1 a    
+      2             2.23 b              B         2 b    
+      3             3.23 c              C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>, $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 52)
     Output
@@ -804,14 +939,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01$col 02~1 $co~2 $co~3 col~4
+                   <dbl> <chr>           <chr> <int> <ord>
+      1             1.23 a               A         1 a    
+      2             2.23 b               B         2 b    
+      3             3.23 c               C         3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>, $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 53)
     Output
@@ -819,14 +956,16 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` `col 05`
-                   <dbl> <chr>             <ord>   
-      1             1.23 a                 a       
-      2             2.23 b                 b       
-      3             3.23 c                 c       
+        column_zero_zero col 01$col 02~1 $col~2 $co~3 col~4
+                   <dbl> <chr>           <chr>  <int> <ord>
+      1             1.23 a               A          1 a    
+      2             2.23 b               B          2 b    
+      3             3.23 c               C          3 c    
       <tbl_format_footer(setup)>
-      # ... with 2 more variables:
-      #   `col 01`$`col 03` <chr>, $`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 02`, 2: $`col 03`,
+      #   3: $`col 04`, 4: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 54)
     Output
@@ -834,15 +973,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero col 01$col 02~1 $`col 03` `col 05`
-                   <dbl> <chr>           <chr>     <ord>   
-      1             1.23 a               A         a       
-      2             2.23 b               B         b       
-      3             3.23 c               C         c       
+        column_zero_zero `col 01`$`col 02` $co~1 $co~2 col~3
+                   <dbl> <chr>             <chr> <int> <ord>
+      1             1.23 a                 A         1 a    
+      2             2.23 b                 B         2 b    
+      3             3.23 c                 C         3 c    
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable name
-      #   1: `col 01`$`col 02`, and 1 more variable:
-      #   `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 03`, 2: $`col 04`, 3: `col 05`,
+      #   and 1 more variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 55)
     Output
@@ -850,14 +989,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $col~1 $co~2 col~3
+                   <dbl> <chr>             <chr>  <int> <ord>
+      1             1.23 a                 A          1 a    
+      2             2.23 b                 B          2 b    
+      3             3.23 c                 C          3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable:
-      #   `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 03`, 2: $`col 04`, 3: `col 05`,
+      #   and 1 more variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 56)
     Output
@@ -865,13 +1005,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $col ~1 $co~2 col~3
+                   <dbl> <chr>             <chr>   <int> <ord>
+      1             1.23 a                 A           1 a    
+      2             2.23 b                 B           2 b    
+      3             3.23 c                 C           3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 03`, 2: $`col 04`, 3: `col 05`,
+      #   and 1 more variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 57)
     Output
@@ -879,13 +1021,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $col 0~1 $co~2 col~3
+                   <dbl> <chr>             <chr>    <int> <ord>
+      1             1.23 a                 A            1 a    
+      2             2.23 b                 B            2 b    
+      3             3.23 c                 C            3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 03`, 2: $`col 04`, 3: `col 05`, and
+      #   1 more variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 58)
     Output
@@ -893,13 +1037,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $co~1 col~2
+                   <dbl> <chr>             <chr>     <int> <ord>
+      1             1.23 a                 A             1 a    
+      2             2.23 b                 B             2 b    
+      3             3.23 c                 C             3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 04`, 2: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 59)
     Output
@@ -907,13 +1053,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col~1 col~2
+                   <dbl> <chr>             <chr>      <int> <ord>
+      1             1.23 a                 A              1 a    
+      2             2.23 b                 B              2 b    
+      3             3.23 c                 C              3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names
+      #   1: `col 01`$`col 04`, 2: `col 05`, and 1 more
+      #   variable: `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 60)
     Output
@@ -921,13 +1069,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col ~1 col~2
+                   <dbl> <chr>             <chr>       <int> <ord>
+      1             1.23 a                 A               1 a    
+      2             2.23 b                 B               2 b    
+      3             3.23 c                 C               3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`,
+      #   2: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 61)
     Output
@@ -935,13 +1085,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 0~1 col~2
+                   <dbl> <chr>             <chr>        <int> <ord>
+      1             1.23 a                 A                1 a    
+      2             2.23 b                 B                2 b    
+      3             3.23 c                 C                3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`,
+      #   2: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 62)
     Output
@@ -949,13 +1101,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04~1 col~2
+                   <dbl> <chr>             <chr>         <int> <ord>
+      1             1.23 a                 A                 1 a    
+      2             2.23 b                 B                 2 b    
+      3             3.23 c                 C                 3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`,
+      #   2: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 63)
     Output
@@ -963,13 +1117,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04[~1 col~2
+                   <dbl> <chr>             <chr>          <int> <ord>
+      1             1.23 a                 A                  1 a    
+      2             2.23 b                 B                  2 b    
+      3             3.23 c                 C                  3 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`,
+      #   2: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04`[2:3] <int>
     Code
       tbl_format_setup(x, width = 64)
     Output
@@ -977,13 +1133,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $co~1 $[,~2 col~3
+                   <dbl> <chr>             <chr>     <int> <int> <ord>
+      1             1.23 a                 A             1     4 a    
+      2             2.23 b                 B             2     5 b    
+      3             3.23 c                 C             3     6 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`,
+      #   2: $, 3: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04`[3] <int>
     Code
       tbl_format_setup(x, width = 65)
     Output
@@ -991,13 +1149,15 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col~1 $[,~2 col~3
+                   <dbl> <chr>             <chr>      <int> <int> <ord>
+      1             1.23 a                 A              1     4 a    
+      2             2.23 b                 B              2     5 b    
+      3             3.23 c                 C              3     6 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`,
+      #   2: $, 3: `col 05`, and 1 more variable:
+      #   `col 01`$`col 04`[3] <int>
     Code
       tbl_format_setup(x, width = 66)
     Output
@@ -1005,13 +1165,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col ~1 $[,~2 col~3
+                   <dbl> <chr>             <chr>       <int> <int> <ord>
+      1             1.23 a                 A               1     4 a    
+      2             2.23 b                 B               2     5 b    
+      3             3.23 c                 C               3     6 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $,
+      #   3: `col 05`, and 1 more variable: `col 01`$`col 04`[3] <int>
     Code
       tbl_format_setup(x, width = 67)
     Output
@@ -1019,13 +1180,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 0~1 $[,~2 col~3
+                   <dbl> <chr>             <chr>        <int> <int> <ord>
+      1             1.23 a                 A                1     4 a    
+      2             2.23 b                 B                2     5 b    
+      3             3.23 c                 C                3     6 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $,
+      #   3: `col 05`, and 1 more variable: `col 01`$`col 04`[3] <int>
     Code
       tbl_format_setup(x, width = 68)
     Output
@@ -1033,13 +1195,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04~1 $[,~2 col~3
+                   <dbl> <chr>             <chr>         <int> <int> <ord>
+      1             1.23 a                 A                 1     4 a    
+      2             2.23 b                 B                 2     5 b    
+      3             3.23 c                 C                 3     6 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $,
+      #   3: `col 05`, and 1 more variable: `col 01`$`col 04`[3] <int>
     Code
       tbl_format_setup(x, width = 69)
     Output
@@ -1047,13 +1210,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` `col 05`
-                   <dbl> <chr>             <chr>     <ord>   
-      1             1.23 a                 A         a       
-      2             2.23 b                 B         b       
-      3             3.23 c                 C         c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04[~1 $[,~2 col~3
+                   <dbl> <chr>             <chr>          <int> <int> <ord>
+      1             1.23 a                 A                  1     4 a    
+      2             2.23 b                 B                  2     5 b    
+      3             3.23 c                 C                  3     6 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04` <int[,3]>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $,
+      #   3: `col 05`, and 1 more variable: `col 01`$`col 04`[3] <int>
     Code
       tbl_format_setup(x, width = 70)
     Output
@@ -1061,14 +1225,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero col 01$col 02~1 $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>           <chr>               <int> <ord>   
-      1             1.23 a               A                       1 a       
-      2             2.23 b               B                       2 b       
-      3             3.23 c               C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $co~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>     <int> <int> <int> <ord>
+      1             1.23 a                 A             1     4     7 a    
+      2             2.23 b                 B             2     5     8 b    
+      3             3.23 c                 C             3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with abbreviated variable name 1: `col 01`$`col 02`, and 1 more
-      #   variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $,
+      #   3: $, 4: `col 05`
     Code
       tbl_format_setup(x, width = 71)
     Output
@@ -1076,13 +1240,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>             <chr>               <int> <ord>   
-      1             1.23 a                 A                       1 a       
-      2             2.23 b                 B                       2 b       
-      3             3.23 c                 C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>      <int> <int> <int> <ord>
+      1             1.23 a                 A              1     4     7 a    
+      2             2.23 b                 B              2     5     8 b    
+      3             3.23 c                 C              3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $,
+      #   3: $, 4: `col 05`
     Code
       tbl_format_setup(x, width = 72)
     Output
@@ -1090,13 +1255,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>             <chr>               <int> <ord>   
-      1             1.23 a                 A                       1 a       
-      2             2.23 b                 B                       2 b       
-      3             3.23 c                 C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col ~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>       <int> <int> <int> <ord>
+      1             1.23 a                 A               1     4     7 a    
+      2             2.23 b                 B               2     5     8 b    
+      3             3.23 c                 C               3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: $,
+      #   4: `col 05`
     Code
       tbl_format_setup(x, width = 73)
     Output
@@ -1104,13 +1270,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>             <chr>               <int> <ord>   
-      1             1.23 a                 A                       1 a       
-      2             2.23 b                 B                       2 b       
-      3             3.23 c                 C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 0~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>        <int> <int> <int> <ord>
+      1             1.23 a                 A                1     4     7 a    
+      2             2.23 b                 B                2     5     8 b    
+      3             3.23 c                 C                3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: $,
+      #   4: `col 05`
     Code
       tbl_format_setup(x, width = 74)
     Output
@@ -1118,13 +1285,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>             <chr>               <int> <ord>   
-      1             1.23 a                 A                       1 a       
-      2             2.23 b                 B                       2 b       
-      3             3.23 c                 C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>         <int> <int> <int> <ord>
+      1             1.23 a                 A                 1     4     7 a    
+      2             2.23 b                 B                 2     5     8 b    
+      3             3.23 c                 C                 3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: $,
+      #   4: `col 05`
     Code
       tbl_format_setup(x, width = 75)
     Output
@@ -1132,13 +1300,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>             <chr>               <int> <ord>   
-      1             1.23 a                 A                       1 a       
-      2             2.23 b                 B                       2 b       
-      3             3.23 c                 C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04[~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>          <int> <int> <int> <ord>
+      1             1.23 a                 A                  1     4     7 a    
+      2             2.23 b                 B                  2     5     8 b    
+      3             3.23 c                 C                  3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: $,
+      #   4: `col 05`
     Code
       tbl_format_setup(x, width = 76)
     Output
@@ -1146,13 +1315,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>             <chr>               <int> <ord>   
-      1             1.23 a                 A                       1 a       
-      2             2.23 b                 B                       2 b       
-      3             3.23 c                 C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04[,~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>           <int> <int> <int> <ord>
+      1             1.23 a                 A                   1     4     7 a    
+      2             2.23 b                 B                   2     5     8 b    
+      3             3.23 c                 C                   3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: $,
+      #   4: `col 05`
     Code
       tbl_format_setup(x, width = 77)
     Output
@@ -1160,13 +1330,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>             <chr>               <int> <ord>   
-      1             1.23 a                 A                       1 a       
-      2             2.23 b                 B                       2 b       
-      3             3.23 c                 C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04[,"~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>            <int> <int> <int> <ord>
+      1             1.23 a                 A                    1     4     7 a    
+      2             2.23 b                 B                    2     5     8 b    
+      3             3.23 c                 C                    3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: $,
+      #   4: `col 05`
     Code
       tbl_format_setup(x, width = 78)
     Output
@@ -1174,13 +1345,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>             <chr>               <int> <ord>   
-      1             1.23 a                 A                       1 a       
-      2             2.23 b                 B                       2 b       
-      3             3.23 c                 C                       3 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04[,"A~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>             <int> <int> <int> <ord>
+      1             1.23 a                 A                     1     4     7 a    
+      2             2.23 b                 B                     2     5     8 b    
+      3             3.23 c                 C                     3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[2:3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: $,
+      #   4: `col 05`
     Code
       tbl_format_setup(x, width = 79)
     Output
@@ -1188,13 +1360,14 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] `col 05`
-                   <dbl> <chr>             <chr>               <int>   <int> <ord>   
-      1             1.23 a                 A                       1       4 a       
-      2             2.23 b                 B                       2       5 b       
-      3             3.23 c                 C                       3       6 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $col 04[,"A"~1 $[,~2 $[,~3 col~4
+                   <dbl> <chr>             <chr>              <int> <int> <int> <ord>
+      1             1.23 a                 A                      1     4     7 a    
+      2             2.23 b                 B                      2     5     8 b    
+      3             3.23 c                 C                      3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: $,
+      #   4: `col 05`
     Code
       tbl_format_setup(x, width = 80)
     Output
@@ -1202,13 +1375,13 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] `col 05`
-                   <dbl> <chr>             <chr>               <int>   <int> <ord>   
-      1             1.23 a                 A                       1       4 a       
-      2             2.23 b                 B                       2       5 b       
-      3             3.23 c                 C                       3       6 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,~1 $[,~2 col~3
+                   <dbl> <chr>             <chr>               <int> <int> <int> <ord>
+      1             1.23 a                 A                       1     4     7 a    
+      2             2.23 b                 B                       2     5     8 b    
+      3             3.23 c                 C                       3     6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: `col 05`
     Code
       tbl_format_setup(x, width = 81)
     Output
@@ -1216,13 +1389,13 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] `col 05`
-                   <dbl> <chr>             <chr>               <int>   <int> <ord>   
-      1             1.23 a                 A                       1       4 a       
-      2             2.23 b                 B                       2       5 b       
-      3             3.23 c                 C                       3       6 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"~1 $[,~2 col~3
+                   <dbl> <chr>             <chr>               <int>  <int> <int> <ord>
+      1             1.23 a                 A                       1      4     7 a    
+      2             2.23 b                 B                       2      5     8 b    
+      3             3.23 c                 C                       3      6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: $, 3: `col 05`
     Code
       tbl_format_setup(x, width = 82)
     Output
@@ -1230,13 +1403,13 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] `col 05`
-                   <dbl> <chr>             <chr>               <int>   <int> <ord>   
-      1             1.23 a                 A                       1       4 a       
-      2             2.23 b                 B                       2       5 b       
-      3             3.23 c                 C                       3       6 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] $[,~1 col~2
+                   <dbl> <chr>             <chr>               <int>   <int> <int> <ord>
+      1             1.23 a                 A                       1       4     7 a    
+      2             2.23 b                 B                       2       5     8 b    
+      3             3.23 c                 C                       3       6     9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: `col 05`
     Code
       tbl_format_setup(x, width = 83)
     Output
@@ -1244,13 +1417,13 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] `col 05`
-                   <dbl> <chr>             <chr>               <int>   <int> <ord>   
-      1             1.23 a                 A                       1       4 a       
-      2             2.23 b                 B                       2       5 b       
-      3             3.23 c                 C                       3       6 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] $[,"~1 col~2
+                   <dbl> <chr>             <chr>               <int>   <int>  <int> <ord>
+      1             1.23 a                 A                       1       4      7 a    
+      2             2.23 b                 B                       2       5      8 b    
+      3             3.23 c                 C                       3       6      9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[3] <int>
+      # ... with abbreviated variable names 1: `col 01`$`col 04`, 2: `col 05`
     Code
       tbl_format_setup(x, width = 84)
     Output
@@ -1258,13 +1431,13 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] `col 05`
-                   <dbl> <chr>             <chr>               <int>   <int> <ord>   
-      1             1.23 a                 A                       1       4 a       
-      2             2.23 b                 B                       2       5 b       
-      3             3.23 c                 C                       3       6 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] $[,"C"] col~1
+                   <dbl> <chr>             <chr>               <int>   <int>   <int> <ord>
+      1             1.23 a                 A                       1       4       7 a    
+      2             2.23 b                 B                       2       5       8 b    
+      3             3.23 c                 C                       3       6       9 c    
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[3] <int>
+      # ... with abbreviated variable name 1: `col 05`
     Code
       tbl_format_setup(x, width = 85)
     Output
@@ -1272,13 +1445,13 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] `col 05`
-                   <dbl> <chr>             <chr>               <int>   <int> <ord>   
-      1             1.23 a                 A                       1       4 a       
-      2             2.23 b                 B                       2       5 b       
-      3             3.23 c                 C                       3       6 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] $[,"C"] col ~1
+                   <dbl> <chr>             <chr>               <int>   <int>   <int> <ord> 
+      1             1.23 a                 A                       1       4       7 a     
+      2             2.23 b                 B                       2       5       8 b     
+      3             3.23 c                 C                       3       6       9 c     
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[3] <int>
+      # ... with abbreviated variable name 1: `col 05`
     Code
       tbl_format_setup(x, width = 86)
     Output
@@ -1286,13 +1459,13 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] `col 05`
-                   <dbl> <chr>             <chr>               <int>   <int> <ord>   
-      1             1.23 a                 A                       1       4 a       
-      2             2.23 b                 B                       2       5 b       
-      3             3.23 c                 C                       3       6 c       
+        column_zero_zero `col 01`$`col 02` $`col 03` $`col 04`[,"A"] $[,"B"] $[,"C"] col 0~1
+                   <dbl> <chr>             <chr>               <int>   <int>   <int> <ord>  
+      1             1.23 a                 A                       1       4       7 a      
+      2             2.23 b                 B                       2       5       8 b      
+      3             3.23 c                 C                       3       6       9 c      
       <tbl_format_footer(setup)>
-      # ... with 1 more variable: `col 01`$`col 04`[3] <int>
+      # ... with abbreviated variable name 1: `col 05`
     Code
       tbl_format_setup(x, width = 87)
     Output

--- a/tests/testthat/_snaps/unicode/ctl_colonnade.md
+++ b/tests/testthat/_snaps/unicode/ctl_colonnade.md
@@ -303,10 +303,13 @@
       [90m# A data frame: 1 ×
       #   2[39m
       [1m<tbl_format_body(setup)>[22m
-          a$x    $y b     
-        [4m[3m[90m<dbl>[39m[23m[24m [4m[3m[90m<dbl>[39m[23m[24m [4m[3m[90m<chr>[39m[23m[24m 
-      [90m1[39m     1     2 long …
+          a$x b          
+        [4m[3m[90m<dbl>[39m[23m[24m [4m[3m[90m<chr>[39m[23m[24m      
+      [90m1[39m     1 long enough
       [1m<tbl_format_footer(setup)>[22m
+      [90m# … with 1 more[39m
+      [90m#   variable:[39m
+      [90m#   a$y <dbl>[39m
     Code
       tbl_format_setup(x, width = 15, focus = c("a", "b"))
     Output

--- a/tests/testthat/test-options.R
+++ b/tests/testthat/test-options.R
@@ -208,27 +208,6 @@ test_that("sigfig", {
   expect_equal(get_pillar_option_sigfig(), orig)
 })
 
-test_that("min_title_chars", {
-  value <- 12L
-
-  orig <- get_pillar_option_min_title_chars()
-  expect_identical(orig, pillar_options$min_title_chars())
-
-  old <- set_pillar_option_min_title_chars(value)
-  expect_equal(get_pillar_option_min_title_chars(), value)
-  expect_equal(expect_invisible(set_pillar_option_min_title_chars(old)), value)
-
-  old <- pillar_options$min_title_chars(value)
-  expect_equal(pillar_options$min_title_chars(), value)
-  expect_equal(expect_invisible(pillar_options$min_title_chars(old)), value)
-
-  local({
-    expect_equal(expect_invisible(local_pillar_option_min_title_chars(value)), old)
-    expect_equal(get_pillar_option_min_title_chars(), value)
-  })
-  expect_equal(get_pillar_option_min_title_chars(), orig)
-})
-
 test_that("min_chars", {
   value <- 5L
 

--- a/tests/testthat/test-tbl-format-setup.R
+++ b/tests/testthat/test-tbl-format-setup.R
@@ -140,8 +140,6 @@ test_that("tbl_format_setup() results", {
 })
 
 test_that("tbl_format_setup() for footnotes", {
-  local_pillar_option_min_title_chars(3)
-
   expect_snapshot({
     tbl_format_setup(width = 73, as_tbl(data_frame(
       xxxabc = 1,
@@ -165,7 +163,6 @@ test_that("tbl_format_setup() for footnotes", {
 test_that("tbl_format_setup() for footnotes with UTF-8 output", {
   skip_if(!l10n_info()$`UTF-8`)
 
-  local_pillar_option_min_title_chars(3)
   local_utf8()
 
   expect_snapshot({


### PR DESCRIPTION
Requires #483, effectively removes effect of `options(pillar.min_title_width = )` .

Do we want a new `desired_width` or `ideal_width` arg to `new_pillar()`? By default it would indicate the width of the data, we wouldn't need to treat the `"data"` component specially.

``` r
palmerpenguins::penguins
#> # A tibble: 344 × 8
#>    species island    bill_length_mm bill_depth_mm flipper_le… body… sex     year
#>    <fct>   <fct>              <dbl>         <dbl>       <int> <int> <fct>  <int>
#>  1 Adelie  Torgersen           39.1          18.7         181  3750 male    2007
#>  2 Adelie  Torgersen           39.5          17.4         186  3800 female  2007
#>  3 Adelie  Torgersen           40.3          18           195  3250 female  2007
#>  4 Adelie  Torgersen           NA            NA            NA    NA <NA>    2007
#>  5 Adelie  Torgersen           36.7          19.3         193  3450 female  2007
#>  6 Adelie  Torgersen           39.3          20.6         190  3650 male    2007
#>  7 Adelie  Torgersen           38.9          17.8         181  3625 female  2007
#>  8 Adelie  Torgersen           39.2          19.6         195  4675 male    2007
#>  9 Adelie  Torgersen           34.1          18.1         193  3475 <NA>    2007
#> 10 Adelie  Torgersen           42            20.2         190  4250 <NA>    2007
#> # … with 334 more rows
```

<sup>Created on 2022-01-31 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>