### PR TITLE
Remove all backticks from abbreviated column names in header

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -151,7 +151,7 @@ jobs:
       - uses: ./.github/workflows/install
         with:
           r-version: ${{ matrix.config.r }}
-          cache-version: rcc-main-1
+          cache-version: rcc-windows-1
           token: ${{ secrets.GITHUB_TOKEN }}
           needs: check
 
@@ -214,7 +214,7 @@ jobs:
       - uses: ./.github/workflows/install
         with:
           r-version: ${{ matrix.config.r }}
-          cache-version: rcc-main-1
+          cache-version: rcc-full-1
           token: ${{ secrets.GITHUB_TOKEN }}
           needs: check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -136,7 +136,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: '4.1'}
           # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -63,16 +63,23 @@ str_add_ellipsis <- function(x, str_width, width, shorten) {
 }
 
 str_add_ellipsis_untick <- function(x, str_width, width, footnote = FALSE) {
+  stopifnot(length(x) == 1)
+  stopifnot(str_width > width)
+
   if (footnote) {
     width <- width - 1L
   }
 
-  rx <- "^(.*[^`])(`?)$"
-  match <- gsub(rx, "\\1", x)
-  rest <- gsub(rx, "\\2", x)
+  # Removing ticks due to https://github.com/tidyverse/tibble/issues/838
+  x_unticked <- gsub("`", "", x, fixed = TRUE)
+  if (x_unticked != x) {
+    x <- x_unticked
+    str_width <- get_extent(x)
+  }
 
-  short <- substr2_ctl(match, 1, width - 1L + get_extent(match) - str_width, type = "width")
-  abbr <- paste0(short, get_ellipsis(), rest)
+  # Add ellipsis even if short enough after removal of ticks
+  abbr <- substr2_ctl(x, 1, width - 1L, type = "width")
+  abbr <- paste0(abbr, get_ellipsis())
 
   if (footnote) {
     # Placeholder, regular title can't end with this string,

--- a/tests/testthat/_snaps/ansi/format_multi.md
+++ b/tests/testthat/_snaps/ansi/format_multi.md
@@ -117,7 +117,7 @@
       `colonnade()` was deprecated in pillar 1.7.0.
       Please use `tbl_format_setup()` instead.
     Output
-        a_very_long_~
+        a_very_long~1
                 [3m[90m<dbl>[39m[23m
       [90m1[39m             0
 

--- a/tests/testthat/_snaps/tbl-format-setup.md
+++ b/tests/testthat/_snaps/tbl-format-setup.md
@@ -527,11 +527,11 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col~`1
-                   <dbl> <chr>           
-      1             1.23 a               
-      2             2.23 b               
-      3             3.23 c               
+        column_zero_zero col 01$col 02~1
+                   <dbl> <chr>          
+      1             1.23 a              
+      2             2.23 b              
+      3             3.23 c              
       <tbl_format_footer(setup)>
       # ... with abbreviated variable
       #   name 1: `col 01`$`col 02`, and
@@ -678,11 +678,11 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col~`1 `col 05`
-                   <dbl> <chr>            <ord>   
-      1             1.23 a                a       
-      2             2.23 b                b       
-      3             3.23 c                c       
+        column_zero_zero col 01$col 02~1 `col 05`
+                   <dbl> <chr>           <ord>   
+      1             1.23 a               a       
+      2             2.23 b               b       
+      3             3.23 c               c       
       <tbl_format_footer(setup)>
       # ... with abbreviated variable name
       #   1: `col 01`$`col 02`, and 2 more
@@ -834,11 +834,11 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col~`1 $`col 03` `col 05`
-                   <dbl> <chr>            <chr>     <ord>   
-      1             1.23 a                A         a       
-      2             2.23 b                B         b       
-      3             3.23 c                C         c       
+        column_zero_zero col 01$col 02~1 $`col 03` `col 05`
+                   <dbl> <chr>           <chr>     <ord>   
+      1             1.23 a               A         a       
+      2             2.23 b               B         b       
+      3             3.23 c               C         c       
       <tbl_format_footer(setup)>
       # ... with abbreviated variable name
       #   1: `col 01`$`col 02`, and 1 more variable:
@@ -1061,11 +1061,11 @@
       <tbl_format_header(setup)>
       # A data frame: 3 x 3
       <tbl_format_body(setup)>
-        column_zero_zero `col 01`$`col~`1 $`col 03` $`col 04`[,"A"] `col 05`
-                   <dbl> <chr>            <chr>               <int> <ord>   
-      1             1.23 a                A                       1 a       
-      2             2.23 b                B                       2 b       
-      3             3.23 c                C                       3 c       
+        column_zero_zero col 01$col 02~1 $`col 03` $`col 04`[,"A"] `col 05`
+                   <dbl> <chr>           <chr>               <int> <ord>   
+      1             1.23 a               A                       1 a       
+      2             2.23 b               B                       2 b       
+      3             3.23 c               C                       3 c       
       <tbl_format_footer(setup)>
       # ... with abbreviated variable name 1: `col 01`$`col 02`, and 1 more
       #   variable: `col 01`$`col 04`[2:3] <int>

--- a/tests/testthat/_snaps/ticks.md
+++ b/tests/testthat/_snaps/ticks.md
@@ -23,13 +23,13 @@
     Code
       format_title("`a b`", 4, footnote = FALSE)
     Output
-      [1] "`a~`"
+      [1] "a b~"
     Code
       format_title("`a b`", 3, footnote = FALSE)
     Output
-      [1] "`~`"
+      [1] "a ~"
     Code
       format_title("`a b`", 3, footnote = FALSE)
     Output
-      [1] "`~`"
+      [1] "a ~"
 


### PR DESCRIPTION
to avoid forgetting closing backtick.