### PR TITLE
Show exact number of rows for dbplyr sources if known

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,6 +30,7 @@ Imports:
     vctrs (>= 0.3.8)
 Suggests: 
     bit64,
+    dbplyr,
     debugme,
     DiagrammeR,
     dplyr,
@@ -41,6 +42,7 @@ Suggests:
     nycflights13,
     palmerpenguins,
     rmarkdown,
+    RSQLite,
     scales,
     stringi,
     survival,

--- a/R/tbl-format-setup.R
+++ b/R/tbl-format-setup.R
@@ -132,6 +132,7 @@ tbl_format_setup.tbl <- function(x, width, ...,
 
   # Header
   tbl_sum <- tbl_sum(x)
+  tbl_sum <- fix_dbplyr_header(tbl_sum, rows)
 
   # Body
   rownames(df) <- NULL
@@ -245,4 +246,13 @@ format.pillar_tbl_format_setup <- function(x, ...) {
     tbl_format_body(x),
     tbl_format_footer(x)
   )
+}
+
+fix_dbplyr_header <- function(tbl_sum, rows) {
+  if (is.na(rows) || !("Source" %in% names2(tbl_sum))) {
+    return(tbl_sum)
+  }
+
+  tbl_sum[["Source"]] <- gsub("[[][?][?] ", paste0("[", rows, " "), tbl_sum[["Source"]])
+  tbl_sum
 }

--- a/tests/testthat/_snaps/tbl-format-setup.md
+++ b/tests/testthat/_snaps/tbl-format-setup.md
@@ -1597,3 +1597,18 @@
       #   ⁵​xxxmno, ⁶​xxxpqr, ⁷​xxxstu, ⁸​xxxvwx, ⁹​xxxyza, ˟​xxxbcd, ˟​xxxefg,
       #   ˟​xxxhij, and 2 more variables: xxxklm <dbl>, xxxnop <dbl>
 
+# row numbers of lazy tables if known (#399)
+
+    Code
+      x <- dbplyr::memdb_frame(a = 1:3)
+      fix_dbplyr_header(tbl_sum(x), 3)["Source"]
+    Output
+                           Source 
+      "table<dbplyr_001> [3 x 1]" 
+    Code
+      x <- dbplyr::memdb_frame(a = 1:11)
+      fix_dbplyr_header(tbl_sum(x), NA_integer_)["Source"]
+    Output
+                            Source 
+      "table<dbplyr_002> [?? x 1]" 
+

--- a/tests/testthat/test-tbl-format-setup.R
+++ b/tests/testthat/test-tbl-format-setup.R
@@ -187,3 +187,15 @@ test_that("tbl_format_setup() for footnotes with UTF-8 output", {
     )))
   })
 })
+
+test_that("row numbers of lazy tables if known (#399)", {
+  skip_if_not_installed("dbplyr")
+  skip_if_not_installed("RSQLite")
+
+  expect_snapshot({
+    x <- dbplyr::memdb_frame(a = 1:3)
+    fix_dbplyr_header(tbl_sum(x), 3)["Source"]
+    x <- dbplyr::memdb_frame(a = 1:11)
+    fix_dbplyr_header(tbl_sum(x), NA_integer_)["Source"]
+  })
+})


### PR DESCRIPTION
It's an ugly hack, search + replace on the table description generated by dbplyr. A clean solution seems out of sight due to how the components interact.

Closes #399.

``` r
dbplyr::memdb_frame(a = 1:3)
#> # Source:   table<dbplyr_001> [3 x 1]
#> # Database: sqlite 3.38.2 [:memory:]
#>       a
#>   <int>
#> 1     1
#> 2     2
#> 3     3
```

<sup>Created on 2022-04-24 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>