### PR TITLE
feat: Pick up `"pillar_focus"` attribute on printing to define focus columns

### DIFF
--- a/R/tbl-format-header.R
+++ b/R/tbl-format-header.R
@@ -33,6 +33,10 @@ tbl_format_header <- function(x, setup, ...) {
 #' @export
 tbl_format_header.tbl <- function(x, setup, ...) {
   named_header <- setup$tbl_sum
+  focus <- attr(x, "pillar_focus")
+  if (!is.null(focus)) {
+    named_header <- c(named_header, "Focus columns" = collapse(tick_if_needed(focus)))
+  }
 
   if (all(names2(named_header) == "")) {
     header <- named_header

--- a/R/tbl-format.R
+++ b/R/tbl-format.R
@@ -67,7 +67,8 @@ format_tbl <- function(x, width = NULL, ...,
     width = width, ...,
     n = n,
     max_extra_cols = max_extra_cols,
-    max_footer_lines = max_footer_lines
+    max_footer_lines = max_footer_lines,
+    focus = attr(x, "pillar_focus")
   )
 
   header <- tbl_format_header(x, setup)

--- a/R/tbl.R
+++ b/R/tbl.R
@@ -1,6 +1,5 @@
 new_tbl <- function(x = list(), n = NULL, ..., class = NULL) {
-  check_dots_empty()
-  new_data_frame(x, n, class = c(class, "tbl"))
+  new_data_frame(x, n, class = c(class, "tbl"), ...)
 }
 
 as_tbl <- function(x, ...) {

--- a/tests/testthat/_snaps/tbl-format-header.md
+++ b/tests/testthat/_snaps/tbl-format-header.md
@@ -26,4 +26,12 @@
       <tbl_format_header(setup)>
       # A data frame: 0 x 0
       # foo:          bar
+    Code
+      # Focus columns
+      tbl_format_header(tbl_format_setup(new_tbl(trees, pillar_focus = "Volume"),
+      width = 30))
+    Output
+      <tbl_format_header(setup)>
+      # A data frame:  31 x 3
+      # Focus columns: Volume
 

--- a/tests/testthat/_snaps/tbl-format.md
+++ b/tests/testthat/_snaps/tbl-format.md
@@ -256,4 +256,26 @@
       10  19.2     6  168.   123  3.92  3.44
       # ... with 22 more rows, and 5 more
       #   variables: qsec <dbl>, ...
+    Code
+      print(tbl_format_setup(new_tbl(trees, pillar_focus = "Volume"), width = 30))
+    Output
+      <pillar_tbl_format_setup>
+      <tbl_format_header(setup)>
+      # A data frame:  31 x 3
+      # Focus columns: Volume
+      <tbl_format_body(setup)>
+         Girth Height Volume
+         <dbl>  <dbl>  <dbl>
+       1   8.3     70   10.3
+       2   8.6     65   10.3
+       3   8.8     63   10.2
+       4  10.5     72   16.4
+       5  10.7     81   18.8
+       6  10.8     83   19.7
+       7  11       66   15.6
+       8  11       75   18.2
+       9  11.1     80   22.6
+      10  11.2     75   19.9
+      <tbl_format_footer(setup)>
+      # ... with 21 more rows
 

--- a/tests/testthat/test-tbl-format-header.R
+++ b/tests/testthat/test-tbl-format-header.R
@@ -12,5 +12,8 @@ test_that("tbl_format_header() results", {
 
     "Custom tbl_sum()"
     tbl_format_header(tbl_format_setup(new_foo_tbl(), width = 30))
+
+    "Focus columns"
+    tbl_format_header(tbl_format_setup(new_tbl(trees, pillar_focus = "Volume"), width = 30))
   })
 })

--- a/tests/testthat/test-tbl-format.R
+++ b/tests/testthat/test-tbl-format.R
@@ -46,6 +46,8 @@ test_that("print() output", {
 
   expect_snapshot({
     print(as_tbl(mtcars), width = 40, n_extra = 1)
+
+    print(tbl_format_setup(new_tbl(trees, pillar_focus = "Volume"), width = 30))
   })
 })
 


### PR DESCRIPTION
from tbl object, for dplyr and dbplyr.