### PR TITLE
Options: New `"pillar.superdigit_sep"` option that determines the string used to separate footnote from column name in the footer

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -137,6 +137,12 @@ pillar_options <- list2(
   bidi = make_option_impl(
     getOption("pillar.bidi", default = FALSE)
   ),
+  #' - `superdigit_sep`: The string inserted between superscript digits
+  #'   and column names in the footnote. Defaults to a `"\u200b"`, a zero-width
+  #'   space, on UTF-8 platforms, and to `": "` on non-UTF-8 platforms.
+  superdigit_sep = make_option_impl(
+    getOption("pillar.superdigit_sep", default = superdigit_sep_default())
+  ),
 )
 
 tibble_opt <- function(x, default) {

--- a/R/tbl-format-footer.R
+++ b/R/tbl-format-footer.R
@@ -93,7 +93,7 @@ format_footer_abbrev_cols <- function(x, setup) {
 
   abbrev_cols <- paste0(
     map_chr(seq_along(abbrev_cols), superdigit),
-    superdigit_sep(),
+    pillar_options$superdigit_sep(),
     abbrev_cols
   )
 

--- a/R/tbl-format-footer.R
+++ b/R/tbl-format-footer.R
@@ -91,7 +91,12 @@ format_footer_abbrev_cols <- function(x, setup) {
     return(NULL)
   }
 
-  abbrev_cols <- paste0(map_chr(seq_along(abbrev_cols), superdigit_pre), abbrev_cols)
+  abbrev_cols <- paste0(
+    map_chr(seq_along(abbrev_cols), superdigit),
+    superdigit_sep(),
+    abbrev_cols
+  )
+
   idx_all_but_last <- seq_len(abbrev_cols_total - 1)
   abbrev_cols[idx_all_but_last] <- paste0(abbrev_cols[idx_all_but_last], ",")
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -191,10 +191,14 @@ superdigit <- function(x) {
   }
 }
 
-superdigit_pre <- function(x) {
+superdigit_sep <- function() {
+  superdigit_sep_default()
+}
+
+superdigit_sep_default <- function() {
   if (cli::is_utf8_output()) {
-    paste0(superdigit(x), "\u200b")
+    "\u200b"
   } else {
-    paste0(superdigit(x), ": ")
+    ": "
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -191,10 +191,6 @@ superdigit <- function(x) {
   }
 }
 
-superdigit_sep <- function() {
-  superdigit_sep_default()
-}
-
 superdigit_sep_default <- function() {
   if (cli::is_utf8_output()) {
     "\u200b"

--- a/man/pillar_options.Rd
+++ b/man/pillar_options.Rd
@@ -72,6 +72,9 @@ and "first strong isolate"
 \href{https://www.w3.org/International/questions/qa-bidi-unicode-controls}{Unicode controls}
 are inserted to ensure that text appears in its intended direction
 and that the column headings correspond to the correct columns.
+\item \code{superdigit_sep}: The string inserted between superscript digits
+and column names in the footnote. Defaults to a \code{"\\u200b"}, a zero-width
+space, on UTF-8 platforms, and to \code{": "} on non-UTF-8 platforms.
 }
 }
 


### PR DESCRIPTION
The zero-width space doesn't work on all browsers.