### PR TITLE
docs: Polish `?pillar_options`

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -3,35 +3,30 @@
 #' Options that affect display of tibble-like output.
 #'
 #' These options can be set via [options()] and queried via [getOption()].
-#' For this, add a `pillar.` prefix (the package name and a dot) to the option name.
-#' Example: for an option `foo`, use `options(pillar.foo = value)` to set it
-#' and `getOption("pillar.foo")` to retrieve the current value.
-#' An option value of `NULL` means that the default is used.
 #'
+#' @usage NULL
 #' @format NULL
 #'
 #' @examples
-#' # Default setting:
-#' getOption("pillar.sigfig")
-#' pillar(1.234567)
+#' df <- tibble::tibble(x = c(1.234567, NA, 5:10))
+#' df
 #'
 #' # Change for the duration of the session:
-#' old <- options(pillar.sigfig = 6)
-#' pillar(1.234567)
+#' old <- options(
+#'   pillar.sigfig = 6,
+#'   pillar.print_max = 5,
+#'   pillar.print_min = 5,
+#'   pillar.advice = FALSE
+#' )
+#' df
 #'
 #' # Change back to the original value:
 #' options(old)
-#' pillar(1.234567)
+#' df
 #'
-#' # Local scope:
-#' local({
-#'   rlang::local_options(pillar.sigfig = 6)
-#'   pillar(1.234567)
-#' })
-#' pillar(1.234567)
 #' @section Options for the pillar package:
 pillar_options <- list2(
-  #' - `print_max`: Maximum number of rows printed, default: `20`.
+  #' - `pillar.print_max`: Maximum number of rows printed, default: `20`.
   #'   Set to \code{Inf} to always print all rows.
   #'   For compatibility reasons, `getOption("tibble.print_max")` and
   #'   `getOption("dplyr.print_max")` are also consulted,
@@ -39,7 +34,7 @@ pillar_options <- list2(
   print_max = make_option_impl(
     getOption("pillar.print_max", default = tibble_opt("print_max", 20L))
   ),
-  #' - `print_min`: Number of rows printed if the table has more than
+  #' - `pillar.print_min`: Number of rows printed if the table has more than
   #'   `print_max` rows, default: `10`.
   #'   For compatibility reasons, `getOption("tibble.print_min")` and
   #'   `getOption("dplyr.print_min")` are also consulted,
@@ -47,7 +42,7 @@ pillar_options <- list2(
   print_min = make_option_impl(
     getOption("pillar.print_min", default = tibble_opt("print_min", 10L))
   ),
-  #' - `width`: Output width. Default: `NULL`
+  #' - `pillar.width`: Output width. Default: `NULL`
   #'   (use `getOption("width")`).
   #'   This can be larger than `getOption("width")`, in this case the output
   #'   of the table's body is distributed over multiple tiers for wide tibbles.
@@ -57,41 +52,41 @@ pillar_options <- list2(
   width = make_option_impl(
     getOption("pillar.width", default = tibble_opt("width", getOption("width")))
   ),
-  #' - `max_footer_lines`: The maximum number of lines in the footer,
+  #' - `pillar.max_footer_lines`: The maximum number of lines in the footer,
   #'     default: `7`. Set to `Inf` to turn off truncation of footer lines.
   #'     The `max_extra_cols` option still limits
   #'     the number of columns printed.
   max_footer_lines = make_option_impl(
     getOption("pillar.max_footer_lines", default = 7L)
   ),
-  #' - `max_extra_cols`: The maximum number of columns printed in the footer,
+  #' - `pillar.max_extra_cols`: The maximum number of columns printed in the footer,
   #'     default: `100`. Set to `Inf` to show all columns.
   #'     Set the more predictable `max_footer_lines` to control the number
   #'     of footer lines instead.
   max_extra_cols = make_option_impl(
     getOption("pillar.max_extra_cols", default = tibble_opt("max_extra_cols", 100L))
   ),
-  #' - `bold`: Use bold font, e.g. for column headers? This currently
+  #' - `pillar.bold`: Use bold font, e.g. for column headers? This currently
   #'     defaults to `FALSE`, because many terminal fonts have poor support for
   #'     bold fonts.
   bold = make_option_impl(
     getOption("pillar.bold", default = FALSE)
   ),
-  #' - `subtle`: Use subtle style, e.g. for row numbers and data types?
+  #' - `pillar.subtle`: Use subtle style, e.g. for row numbers and data types?
   #'     Default: `TRUE`.
   subtle = make_option_impl(
     getOption("pillar.subtle", default = TRUE)
   ),
-  #' - `subtle_num`: Use subtle style for insignificant digits? Default:
+  #' - `pillar.subtle_num`: Use subtle style for insignificant digits? Default:
   #'     `FALSE`, is also affected by the `subtle` option.
   subtle_num = make_option_impl(
     getOption("pillar.subtle_num", default = FALSE)
   ),
-  #' - `neg`: Highlight negative numbers? Default: `TRUE`.
+  #' - `pillar.neg`: Highlight negative numbers? Default: `TRUE`.
   neg = make_option_impl(
     getOption("pillar.neg", default = TRUE)
   ),
-  #' - `sigfig`: The number of significant digits that will be printed and
+  #' - `pillar.sigfig`: The number of significant digits that will be printed and
   #'     highlighted, default: `3`. Set the `subtle` option to `FALSE` to
   #'     turn off highlighting of significant digits.
   sigfig = make_option_impl(option_name = "pillar.sigfig", {
@@ -103,15 +98,15 @@ pillar_options <- list2(
     }
     sigfig
   }),
-  #' - `min_title_chars`: The minimum number of characters for the column
-  #'     title, default: `3`.  Column titles may be truncated up to that width to
+  #' - `pillar.min_title_chars`: The minimum number of characters for the column
+  #'     title, default: `5`.  Column titles may be truncated up to that width to
   #'     save horizontal space. Set to `Inf` to turn off truncation of column
   #'     titles.
   min_title_chars = make_option_impl(
     getOption("pillar.min_title_chars", default = 5L)
   ),
-  #' - `min_chars`: The minimum number of characters wide to
-  #'     display character columns, default: `5`.  Character columns may be
+  #' - `pillar.min_chars`: The minimum number of characters wide to
+  #'     display character columns, default: `3`.  Character columns may be
   #'     truncated up to that width to save horizontal space. Set to `Inf` to
   #'     turn off truncation of character columns.
   min_chars = make_option_impl(option_name = "pillar.min_chars", {
@@ -123,12 +118,12 @@ pillar_options <- list2(
     }
     min_chars
   }),
-  #' - `max_dec_width`: The maximum allowed width for decimal notation,
+  #' - `pillar.max_dec_width`: The maximum allowed width for decimal notation,
   #'     default: `13`.
   max_dec_width = make_option_impl(
     getOption("pillar.max_dec_width", default = 13L)
   ),
-  #' - `bidi`: Set to `TRUE` for experimental support for bidirectional scripts.
+  #' - `pillar.bidi`: Set to `TRUE` for experimental support for bidirectional scripts.
   #'     Default: `FALSE`. When this option is set, "left right override"
   #'     and "first strong isolate"
   #'     [Unicode controls](https://www.w3.org/International/questions/qa-bidi-unicode-controls)
@@ -137,13 +132,13 @@ pillar_options <- list2(
   bidi = make_option_impl(
     getOption("pillar.bidi", default = FALSE)
   ),
-  #' - `superdigit_sep`: The string inserted between superscript digits
+  #' - `pillar.superdigit_sep`: The string inserted between superscript digits
   #'   and column names in the footnote. Defaults to a `"\u200b"`, a zero-width
   #'   space, on UTF-8 platforms, and to `": "` on non-UTF-8 platforms.
   superdigit_sep = make_option_impl(
     getOption("pillar.superdigit_sep", default = superdigit_sep_default())
   ),
-  #' - `advice`: Should advice be displayed in the footer when columns or rows
+  #' - `pillar.advice`: Should advice be displayed in the footer when columns or rows
   #'   are missing from the output? Defaults to `TRUE` for interactive sessions,
   #'   and to `FALSE` otherwise.
   advice = make_option_impl(

--- a/man/pillar_options.Rd
+++ b/man/pillar_options.Rd
@@ -4,101 +4,92 @@
 \name{pillar_options}
 \alias{pillar_options}
 \title{Package options}
-\usage{
-pillar_options
-}
 \description{
 Options that affect display of tibble-like output.
 }
 \details{
 These options can be set via \code{\link[=options]{options()}} and queried via \code{\link[=getOption]{getOption()}}.
-For this, add a \code{pillar.} prefix (the package name and a dot) to the option name.
-Example: for an option \code{foo}, use \code{options(pillar.foo = value)} to set it
-and \code{getOption("pillar.foo")} to retrieve the current value.
-An option value of \code{NULL} means that the default is used.
 }
 \section{Options for the pillar package}{
 
 \itemize{
-\item \code{print_max}: Maximum number of rows printed, default: \code{20}.
+\item \code{pillar.print_max}: Maximum number of rows printed, default: \code{20}.
 Set to \code{Inf} to always print all rows.
 For compatibility reasons, \code{getOption("tibble.print_max")} and
 \code{getOption("dplyr.print_max")} are also consulted,
 this will be soft-deprecated in pillar v2.0.0.
-\item \code{print_min}: Number of rows printed if the table has more than
+\item \code{pillar.print_min}: Number of rows printed if the table has more than
 \code{print_max} rows, default: \code{10}.
 For compatibility reasons, \code{getOption("tibble.print_min")} and
 \code{getOption("dplyr.print_min")} are also consulted,
 this will be soft-deprecated in pillar v2.0.0.
-\item \code{width}: Output width. Default: \code{NULL}
+\item \code{pillar.width}: Output width. Default: \code{NULL}
 (use \code{getOption("width")}).
 This can be larger than \code{getOption("width")}, in this case the output
 of the table's body is distributed over multiple tiers for wide tibbles.
 For compatibility reasons, \code{getOption("tibble.width")} and
 \code{getOption("dplyr.width")} are also consulted,
 this will be soft-deprecated in pillar v2.0.0.
-\item \code{max_footer_lines}: The maximum number of lines in the footer,
+\item \code{pillar.max_footer_lines}: The maximum number of lines in the footer,
 default: \code{7}. Set to \code{Inf} to turn off truncation of footer lines.
 The \code{max_extra_cols} option still limits
 the number of columns printed.
-\item \code{max_extra_cols}: The maximum number of columns printed in the footer,
+\item \code{pillar.max_extra_cols}: The maximum number of columns printed in the footer,
 default: \code{100}. Set to \code{Inf} to show all columns.
 Set the more predictable \code{max_footer_lines} to control the number
 of footer lines instead.
-\item \code{bold}: Use bold font, e.g. for column headers? This currently
+\item \code{pillar.bold}: Use bold font, e.g. for column headers? This currently
 defaults to \code{FALSE}, because many terminal fonts have poor support for
 bold fonts.
-\item \code{subtle}: Use subtle style, e.g. for row numbers and data types?
+\item \code{pillar.subtle}: Use subtle style, e.g. for row numbers and data types?
 Default: \code{TRUE}.
-\item \code{subtle_num}: Use subtle style for insignificant digits? Default:
+\item \code{pillar.subtle_num}: Use subtle style for insignificant digits? Default:
 \code{FALSE}, is also affected by the \code{subtle} option.
-\item \code{neg}: Highlight negative numbers? Default: \code{TRUE}.
-\item \code{sigfig}: The number of significant digits that will be printed and
+\item \code{pillar.neg}: Highlight negative numbers? Default: \code{TRUE}.
+\item \code{pillar.sigfig}: The number of significant digits that will be printed and
 highlighted, default: \code{3}. Set the \code{subtle} option to \code{FALSE} to
 turn off highlighting of significant digits.
-\item \code{min_title_chars}: The minimum number of characters for the column
-title, default: \code{3}.  Column titles may be truncated up to that width to
+\item \code{pillar.min_title_chars}: The minimum number of characters for the column
+title, default: \code{5}.  Column titles may be truncated up to that width to
 save horizontal space. Set to \code{Inf} to turn off truncation of column
 titles.
-\item \code{min_chars}: The minimum number of characters wide to
-display character columns, default: \code{5}.  Character columns may be
+\item \code{pillar.min_chars}: The minimum number of characters wide to
+display character columns, default: \code{3}.  Character columns may be
 truncated up to that width to save horizontal space. Set to \code{Inf} to
 turn off truncation of character columns.
-\item \code{max_dec_width}: The maximum allowed width for decimal notation,
+\item \code{pillar.max_dec_width}: The maximum allowed width for decimal notation,
 default: \code{13}.
-\item \code{bidi}: Set to \code{TRUE} for experimental support for bidirectional scripts.
+\item \code{pillar.bidi}: Set to \code{TRUE} for experimental support for bidirectional scripts.
 Default: \code{FALSE}. When this option is set, "left right override"
 and "first strong isolate"
 \href{https://www.w3.org/International/questions/qa-bidi-unicode-controls}{Unicode controls}
 are inserted to ensure that text appears in its intended direction
 and that the column headings correspond to the correct columns.
-\item \code{superdigit_sep}: The string inserted between superscript digits
+\item \code{pillar.superdigit_sep}: The string inserted between superscript digits
 and column names in the footnote. Defaults to a \code{"\\u200b"}, a zero-width
 space, on UTF-8 platforms, and to \code{": "} on non-UTF-8 platforms.
-\item \code{advice}: Should advice be displayed in the footer when columns or rows
+\item \code{pillar.advice}: Should advice be displayed in the footer when columns or rows
 are missing from the output? Defaults to \code{TRUE} for interactive sessions,
 and to \code{FALSE} otherwise.
 }
 }
 
 \examples{
-# Default setting:
-getOption("pillar.sigfig")
-pillar(1.234567)
+df <- tibble::tibble(x = c(1.234567, NA, 5:10))
+df
 
 # Change for the duration of the session:
-old <- options(pillar.sigfig = 6)
-pillar(1.234567)
+old <- options(
+  pillar.sigfig = 6,
+  pillar.print_max = 5,
+  pillar.print_min = 5,
+  pillar.advice = FALSE
+)
+df
 
 # Change back to the original value:
 options(old)
-pillar(1.234567)
+df
 
-# Local scope:
-local({
-  rlang::local_options(pillar.sigfig = 6)
-  pillar(1.234567)
-})
-pillar(1.234567)
 }
 \keyword{datasets}


### PR DESCRIPTION
* Supress usage since object is not exported
* Use `pillar.` on all options since it makes the documentation easier to understand
* Rework the example to use a tibble and set more options.
* Correct default values