### PR TITLE
fix: Fix printing of very small numbers

### DIFF
--- a/R/sigfig.R
+++ b/R/sigfig.R
@@ -175,7 +175,7 @@ safe_signif <- function(x, digits) {
 safe_divide_10_to <- function(x, y) {
   # Computes x / 10^y in a robust way
 
-  x / (10^y)
+  10 ^ (log10(x) - y)
 }
 
 eps_2 <- 2 * .Machine$double.eps

--- a/R/sigfig.R
+++ b/R/sigfig.R
@@ -175,7 +175,7 @@ safe_signif <- function(x, digits) {
 safe_divide_10_to <- function(x, y) {
   # Computes x / 10^y in a robust way
 
-  10 ^ (log10(x) - y)
+  10^(log10(x) - y)
 }
 
 eps_2 <- 2 * .Machine$double.eps


### PR DESCRIPTION
This variant seems to be slightly more numerically stable than the `exp()` variant.

``` r
pillar::pillar(4e-324)
#> <pillar>
#>     <dbl>
#> 4.94e-324
```

<sup>Created on 2022-10-30 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Closes #615.