### PR TITLE
fix: Show colnames() hint only when needed

### DIFF
--- a/R/tbl-format-footer.R
+++ b/R/tbl-format-footer.R
@@ -125,7 +125,7 @@ format_footer_advice <- function(x, setup) {
     return()
   }
 
-  if (length(setup$extra_cols) > 0) {
+  if (length(setup$extra_cols) > setup$extra_cols_total) {
     cols <- "`colnames()` to see all variable names"
   } else {
     cols <- NULL

--- a/tests/testthat/_snaps/tbl-format-footer.md
+++ b/tests/testthat/_snaps/tbl-format-footer.md
@@ -166,7 +166,6 @@
       <tbl_format_footer(setup)>
       # * 13 more variables: n <chr>, o <chr>, p <chr>, q <chr>, r <chr>, s <chr>,
       #   t <chr>, u <chr>, v <chr>, w <chr>, x <chr>, y <chr>, z <chr>
-      # i Use `colnames()` to see all variable names
 
 # advice when interactive (#575)
 
@@ -176,7 +175,6 @@
       <tbl_format_footer(setup)>
       # * 13 more variables: n <chr>, o <chr>, p <chr>, q <chr>, r <chr>, s <chr>,
       #   t <chr>, u <chr>, v <chr>, w <chr>, x <chr>, y <chr>, z <chr>
-      # i Use `colnames()` to see all variable names
     Code
       tbl_format_footer(tbl_format_setup(new_tbl(list(a = 1:30)), width = 80))
     Output


### PR DESCRIPTION
Closes https://github.com/tidyverse/tibble/issues/1488.