### PR TITLE
fix: Avoid warning with S4 character classes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Imports:
     vctrs (>= 0.5.0)
 Suggests: 
     bit64,
+    DBI,
     debugme,
     DiagrammeR,
     dplyr,

--- a/R/shaft-.R
+++ b/R/shaft-.R
@@ -313,6 +313,11 @@ pillar_shaft.character <- function(x, ..., min_width = NULL) {
     min_chars <- get_pillar_option_min_chars()
   }
 
+  if (isS4(out)) {
+    # Remove S4 bit:
+    out <- unclass(out)[seq_along(out)]
+  }
+
   pillar_shaft(as_glue(out), ..., min_width = min_chars, na_indent = na_indent, shorten = pillar_attr$shorten)
 }
 

--- a/tests/testthat/_snaps/shaft-.md
+++ b/tests/testthat/_snaps/shaft-.md
@@ -1,0 +1,9 @@
+# S4 character class (tidyverse/tibble#1367)
+
+    Code
+      pillar(DBI::SQL("x"))
+    Output
+      <pillar>
+      <SQL>
+      x    
+

--- a/tests/testthat/test-shaft-.R
+++ b/tests/testthat/test-shaft-.R
@@ -1,0 +1,6 @@
+test_that("S4 character class (tidyverse/tibble#1367)", {
+  skip_if_not_installed("DBI")
+  expect_snapshot({
+    pillar(DBI::SQL("x"))
+  })
+})


### PR DESCRIPTION
Closes https://github.com/tidyverse/tibble/issues/1367.