### PR TITLE
Better decimal formatting

### DIFF
--- a/R/sigfig.R
+++ b/R/sigfig.R
@@ -339,7 +339,7 @@ format_dec <- function(s) {
 
   # Decimal column
   if (any(dec)) {
-    dec_col <- ifelse(dec, style_num(".", neg, !lhs_zero), " ")
+    dec_col <- ifelse(dec, style_num(getOption("OutDec"), neg, !lhs_zero), " ")
   } else {
     dec_col <- rep_along(neg, "")
   }


### PR DESCRIPTION
Makes sure that pillar formats decimals according to the decimal mark defined by the user with the "OutDec" option (as described in help("options")).