### PR TITLE
docs: Fix typo & missing quote in digits vignette stub

### DIFF
--- a/vignettes/digits.Rmd
+++ b/vignettes/digits.Rmd
@@ -7,4 +7,4 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-This content has moved to `vignette("digits", packages = "tibble)`.
+This content has moved to `vignette("digits", package = "tibble")`.


### PR DESCRIPTION
Fixes a typo in argument name and adds the missing double quote.