### PR TITLE
docs: Avoid displaying deprecated argument in `@inheritDotParams`

### DIFF
--- a/R/ggplot2.R
+++ b/R/ggplot2.R
@@ -5,7 +5,7 @@
 #'
 #' This scale is used by default in ggplot2 with columns created with [num()].
 #'
-#' @inheritDotParams ggplot2::continuous_scale
+#' @inheritDotParams ggplot2::continuous_scale -scale_name
 #' @param guide,position Passed on to [ggplot2::continuous_scale()]
 #' @param rescaler,super Must remain `NULL`.
 #'

--- a/man/scale_x_num.Rd
+++ b/man/scale_x_num.Rd
@@ -20,8 +20,6 @@ scale_y_num(..., guide = ggplot2::waiver(), rescaler = NULL, super = NULL)
   Arguments passed on to \code{\link[ggplot2:continuous_scale]{ggplot2::continuous_scale}}
   \describe{
     \item{\code{aesthetics}}{The names of the aesthetics that this scale works with.}
-    \item{\code{scale_name}}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} The name of the scale
-that should be used for error messages associated with this scale.}
     \item{\code{palette}}{A palette function that when called with a numeric vector with
 values between 0 and 1 returns the corresponding output values
 (e.g., \code{\link[scales:pal_area]{scales::pal_area()}}).}


### PR DESCRIPTION
Deprecated in ggplot2 3.5.0.

Follow-up to https://github.com/r-lib/pillar/commit/9e8704e4574f09d96f93b3780201d9c461f6fb4c