### PR TITLE
feat: Math operations on `num()` objects now pass additional arguments to the mathematical function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,9 @@
 
 # pillar 1.9.0.9008
 
-- Internal changes only.
+## Bug fixes
 
+- Math operations on `num()` objects now pass additional arguments to the mathematical function (@gvelasq, #660).
 
 # pillar 1.9.0.9007
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,9 +2,8 @@
 
 # pillar 1.9.0.9008
 
-## Bug fixes
+- Internal changes only.
 
-- Math operations on `num()` objects now pass additional arguments to the mathematical function (@gvelasq, #660).
 
 # pillar 1.9.0.9007
 

--- a/R/num.R
+++ b/R/num.R
@@ -127,7 +127,7 @@ vec_arith.numeric.pillar_num <- vec_arith.pillar_num.default
 vec_math.pillar_num <- function(.fn, .x, ...) {
   "!!!!DEBUG vec_math(`v(.fn)`)"
 
-  out <- vec_math_base(.fn, vec_proxy(.x))
+  out <- vec_math_base(.fn, vec_proxy(.x), ...)
 
   if (is.numeric(out)) {
     out <- vec_restore(out, .x)

--- a/tests/testthat/_snaps/ggplot2/log-scale.svg
+++ b/tests/testthat/_snaps/ggplot2/log-scale.svg
@@ -20,54 +20,50 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
 </g>
 <defs>
-  <clipPath id='cpMTMxLjM0fDcwMi4wN3w3NC41Nnw0NTYuNTQ='>
-    <rect x='131.34' y='74.56' width='570.72' height='381.97' />
+  <clipPath id='cpMTE1LjMxfDcwMi4wN3w3NC41Nnw0NTYuNTQ='>
+    <rect x='115.31' y='74.56' width='586.76' height='381.97' />
   </clipPath>
 </defs>
-<g clip-path='url(#cpMTMxLjM0fDcwMi4wN3w3NC41Nnw0NTYuNTQ=)'>
-<polyline points='131.34,422.20 702.07,422.20 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='131.34,338.42 702.07,338.42 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='131.34,254.64 702.07,254.64 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='131.34,170.86 702.07,170.86 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='131.34,87.07 702.07,87.07 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='171.70,456.54 171.70,74.56 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='315.82,456.54 315.82,74.56 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='459.94,456.54 459.94,74.56 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='604.06,456.54 604.06,74.56 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='131.34,380.31 702.07,380.31 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='131.34,296.53 702.07,296.53 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='131.34,212.75 702.07,212.75 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='131.34,128.96 702.07,128.96 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='243.76,456.54 243.76,74.56 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='387.88,456.54 387.88,74.56 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='532.00,456.54 532.00,74.56 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
-<polyline points='676.13,456.54 676.13,74.56 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
-<circle cx='157.29' cy='439.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='214.93' cy='400.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='272.58' cy='362.01' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='330.23' cy='323.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='387.88' cy='284.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='445.53' cy='246.26' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='503.18' cy='207.68' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='560.83' cy='169.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='618.48' cy='130.51' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
-<circle cx='676.13' cy='91.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<g clip-path='url(#cpMTE1LjMxfDcwMi4wN3w3NC41Nnw0NTYuNTQ=)'>
+<polyline points='115.31,419.88 702.07,419.88 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='115.31,304.13 702.07,304.13 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='115.31,188.38 702.07,188.38 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='156.80,456.54 156.80,74.56 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='304.97,456.54 304.97,74.56 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='453.14,456.54 453.14,74.56 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='601.31,456.54 601.31,74.56 ' style='stroke-width: 1.75; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='115.31,362.01 702.07,362.01 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='115.31,246.26 702.07,246.26 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='115.31,130.51 702.07,130.51 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='230.88,456.54 230.88,74.56 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='379.05,456.54 379.05,74.56 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='527.22,456.54 527.22,74.56 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
+<polyline points='675.40,456.54 675.40,74.56 ' style='stroke-width: 3.49; stroke: #EBEBEB; stroke-linecap: butt;' />
+<circle cx='141.98' cy='439.17' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='201.25' cy='400.59' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='260.52' cy='362.01' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='319.78' cy='323.43' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='379.05' cy='284.84' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='438.32' cy='246.26' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='497.59' cy='207.68' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='556.86' cy='169.09' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='616.13' cy='130.51' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
+<circle cx='675.40' cy='91.93' r='1.95' style='stroke-width: 0.71; fill: #000000;' />
 </g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8MC4wMHw1NzYuMDA=)'>
-<text x='115.20' y='390.22' text-anchor='end' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='48.06px' lengthAdjust='spacingAndGlyphs'>10n</text>
-<text x='115.20' y='306.44' text-anchor='end' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='40.02px' lengthAdjust='spacingAndGlyphs'>1m</text>
-<text x='115.20' y='222.66' text-anchor='end' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='56.06px' lengthAdjust='spacingAndGlyphs'>100 </text>
-<text x='115.20' y='138.87' text-anchor='end' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='56.04px' lengthAdjust='spacingAndGlyphs'>10M</text>
-<text x='243.76' y='492.50' text-anchor='middle' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='32.04px' lengthAdjust='spacingAndGlyphs'>25</text>
-<text x='387.88' y='492.50' text-anchor='middle' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='32.04px' lengthAdjust='spacingAndGlyphs'>50</text>
-<text x='532.00' y='492.50' text-anchor='middle' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='32.04px' lengthAdjust='spacingAndGlyphs'>75</text>
-<text x='676.13' y='492.50' text-anchor='middle' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='48.06px' lengthAdjust='spacingAndGlyphs'>100</text>
-<text x='361.47' y='543.12' style='font-size: 36.00px; font-family: sans;' textLength='18.01px' lengthAdjust='spacingAndGlyphs'>x</text>
-<text x='379.48' y='543.12' style='font-size: 36.00px; font-family: sans;' textLength='20.00px' lengthAdjust='spacingAndGlyphs'> [</text>
-<text x='399.49' y='543.12' style='font-size: 36.00px; font-family: sans;' textLength='40.05px' lengthAdjust='spacingAndGlyphs'>10</text>
-<text x='439.53' y='525.04' style='font-size: 25.20px; font-family: sans;' textLength='22.41px' lengthAdjust='spacingAndGlyphs'>-3</text>
-<text x='461.94' y='543.12' style='font-size: 36.00px; font-family: sans;' textLength='10.00px' lengthAdjust='spacingAndGlyphs'>]</text>
+<text x='99.17' y='371.92' text-anchor='end' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='40.02px' lengthAdjust='spacingAndGlyphs'>1m</text>
+<text x='99.17' y='256.17' text-anchor='end' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='24.02px' lengthAdjust='spacingAndGlyphs'>1 </text>
+<text x='99.17' y='140.42' text-anchor='end' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='30.43px' lengthAdjust='spacingAndGlyphs'>1k</text>
+<text x='230.88' y='492.50' text-anchor='middle' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='32.04px' lengthAdjust='spacingAndGlyphs'>25</text>
+<text x='379.05' y='492.50' text-anchor='middle' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='32.04px' lengthAdjust='spacingAndGlyphs'>50</text>
+<text x='527.22' y='492.50' text-anchor='middle' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='32.04px' lengthAdjust='spacingAndGlyphs'>75</text>
+<text x='675.40' y='492.50' text-anchor='middle' style='font-size: 28.80px; fill: #4D4D4D; font-family: sans;' textLength='48.06px' lengthAdjust='spacingAndGlyphs'>100</text>
+<text x='353.45' y='543.12' style='font-size: 36.00px; font-family: sans;' textLength='18.01px' lengthAdjust='spacingAndGlyphs'>x</text>
+<text x='371.47' y='543.12' style='font-size: 36.00px; font-family: sans;' textLength='20.00px' lengthAdjust='spacingAndGlyphs'> [</text>
+<text x='391.47' y='543.12' style='font-size: 36.00px; font-family: sans;' textLength='40.05px' lengthAdjust='spacingAndGlyphs'>10</text>
+<text x='431.51' y='525.04' style='font-size: 25.20px; font-family: sans;' textLength='22.41px' lengthAdjust='spacingAndGlyphs'>-3</text>
+<text x='453.92' y='543.12' style='font-size: 36.00px; font-family: sans;' textLength='10.00px' lengthAdjust='spacingAndGlyphs'>]</text>
 <text transform='translate(42.71,265.55) rotate(-90)' text-anchor='middle' style='font-size: 36.00px; font-family: sans;' textLength='18.01px' lengthAdjust='spacingAndGlyphs'>z</text>
-<text x='131.34' y='47.66' style='font-size: 43.20px; font-family: sans;' textLength='182.55px' lengthAdjust='spacingAndGlyphs'>log_scale</text>
+<text x='115.31' y='47.66' style='font-size: 43.20px; font-family: sans;' textLength='182.55px' lengthAdjust='spacingAndGlyphs'>log_scale</text>
 </g>
 </svg>

--- a/tests/testthat/_snaps/num.md
+++ b/tests/testthat/_snaps/num.md
@@ -467,6 +467,11 @@
     Output
       <pillar_num{%}*100[3]>
       [1] 84.1 90.9 14.1
+    Code
+      sum(num(c(1:3, NA)), na.rm = TRUE)
+    Output
+      <pillar_num[1]>
+      [1] 6
 
 # formatting
 

--- a/tests/testthat/test-ggplot2.R
+++ b/tests/testthat/test-ggplot2.R
@@ -19,7 +19,7 @@ test_that("ggplot2 snapshot tests", {
   log_scale <-
     ggplot2::ggplot(data, ggplot2::aes(x, z)) +
     ggplot2::geom_point() +
-    scale_y_num(trans = "log10") +
+    scale_y_num(transform = "log10") +
     ggplot2::theme_minimal(36)
 
   vdiffr::expect_doppelganger("log_scale", log_scale)

--- a/tests/testthat/test-num.R
+++ b/tests/testthat/test-num.R
@@ -170,6 +170,7 @@ test_that("mathematics", {
     min(num(1:3, label = "$"))
     mean(num(1:3, notation = "eng"))
     sin(num(1:3, label = "%", scale = 100))
+    sum(num(c(1:3, NA)), na.rm = TRUE)
   })
 })
 


### PR DESCRIPTION
Fixes #659

Thank you for considering a pull request. As I looked into this, I noticed that `sum()` and other functions that take additional arguments (e.g., `mean()`, `prod()`) are handled by [`vec_math_base()`](https://vctrs.r-lib.org/reference/vec_math.html) instead of [`vec_arith_base()`](https://vctrs.r-lib.org/reference/vec_arith.html). I passed the ellipsis to `vec_math_base()` which now performs the correct calculation, and I added a test which passes.

``` r
# current behavior
library(pillar)
sum(num(c(1:3, NA)), na.rm = TRUE)
#> <pillar_num[1]>
#> [1] NA

# proposed behavior
devtools::load_all("~/rrr/pillar", quiet = TRUE)
sum(num(c(1:3, NA)), na.rm = TRUE)
#> <pillar_num[1]>
#> [1] 6
```

<sup>Created on 2024-06-16 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>