### PR TITLE
docs: Update _pkgdown.yml to bring back search bar

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -71,7 +71,6 @@ navbar:
     - articles
     - tutorials
     - news
-    right: github
   components:
     options:
       text: Options


### PR DESCRIPTION
To show search bar (With pkgdown 2.1, `search` has to be manually specified. by removing `right`, the `search` will naturally appear.

This will also enable lightswitch to be added automatically when tidytemplate is updated tidyverse/tidytemplate#81