### PR TITLE
docs: Define `type_sum.accel()` only in help page to avoid silent errors when loading

### DIFF
--- a/R/type.R
+++ b/R/type.R
@@ -76,13 +76,17 @@ format_full_pillar_type <- function(x) {
 #' @export
 #' @examples
 #' # Default method: show the type with angle brackets
-#' format_type_sum(1, NULL)
+#' writeLines(format_type_sum("dbl", width = NULL))
 #' pillar(1)
 #'
 #' # AsIs method: show the type without angle brackets
 #' type_sum.accel <- function(x) {
 #'   I("kg m/s^2")
 #' }
+#'
+#' # Typically done through NAMESPACE
+#' # (perhaps with an @export directive in roxygen2)
+#' registerS3method("type_sum", "accel", type_sum.accel)
 #'
 #' accel <- structure(9.81, class = "accel")
 #' pillar(accel)

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -36,13 +36,6 @@
 #' @importFrom cli symbol ansi_strwrap
 NULL
 
-# https://github.com/r-lib/pkgdown/issues/1540
-if (Sys.getenv("IN_PKGDOWN") != "") {
-  type_sum.accel <- function(x) {
-    I("kg m/s^2")
-  }
-}
-
 # nolint start
 .onLoad <- function(libname, pkgname) {
   # nolint end
@@ -65,11 +58,6 @@ if (Sys.getenv("IN_PKGDOWN") != "") {
     # activate_debugme()
     debugme::debugme()
     debug_info()
-  }
-
-  # https://github.com/r-lib/pkgdown/issues/1540
-  if (Sys.getenv("IN_PKGDOWN") != "") {
-    s3_register("pillar::type_sum", "accel")
   }
 
   invisible()

--- a/man/format_type_sum.Rd
+++ b/man/format_type_sum.Rd
@@ -33,13 +33,17 @@ For even more control over the formatting, implement your own method.
 }
 \examples{
 # Default method: show the type with angle brackets
-format_type_sum(1, NULL)
+writeLines(format_type_sum("dbl", width = NULL))
 pillar(1)
 
 # AsIs method: show the type without angle brackets
 type_sum.accel <- function(x) {
   I("kg m/s^2")
 }
+
+# Typically done through NAMESPACE
+# (perhaps with an @export directive in roxygen2)
+registerS3method("type_sum", "accel", type_sum.accel)
 
 accel <- structure(9.81, class = "accel")
 pillar(accel)


### PR DESCRIPTION
Closes #720.

Closes #668.