### PR TITLE
fix: `print()` and `format()` pass on `...` to `tbl_format_setup()` again, as documented

### DIFF
--- a/R/tbl-format.R
+++ b/R/tbl-format.R
@@ -52,7 +52,7 @@ format_tbl <- function(
   max_footer_lines = NULL,
   transform = identity
 ) {
-  check_dots_empty(error = function(cnd) warn("`...` must be empty in `format.tbl()`", parent = cnd))
+  check_dots_used()
 
   if (!is.null(n_extra)) {
     deprecate_stop("1.6.2", "pillar::format(n_extra = )", "pillar::format(max_extra_cols = )")

--- a/tests/testthat/_snaps/tbl-format.md
+++ b/tests/testthat/_snaps/tbl-format.md
@@ -273,3 +273,49 @@
       <tbl_format_footer(setup)>
       # i 21 more rows
 
+# print() and format() can pass down arguments in `...`
+
+    Code
+      format(tbl, known_arg = TRUE)
+    Output
+       [1] "# A data frame: 31 x 3" "# Attribute:    Set"    "   Girth Height Volume"
+       [4] "   <dbl>  <dbl>  <dbl>" " 1   8.3     70   10.3" " 2   8.6     65   10.3"
+       [7] " 3   8.8     63   10.2" " 4  10.5     72   16.4" " 5  10.7     81   18.8"
+      [10] " 6  10.8     83   19.7" " 7  11       66   15.6" " 8  11       75   18.2"
+      [13] " 9  11.1     80   22.6" "10  11.2     75   19.9" "# i 21 more rows"      
+    Code
+      print(tbl, known_arg = TRUE)
+    Output
+      # A data frame: 31 x 3
+      # Attribute:    Set
+         Girth Height Volume
+         <dbl>  <dbl>  <dbl>
+       1   8.3     70   10.3
+       2   8.6     65   10.3
+       3   8.8     63   10.2
+       4  10.5     72   16.4
+       5  10.7     81   18.8
+       6  10.8     83   19.7
+       7  11       66   15.6
+       8  11       75   18.2
+       9  11.1     80   22.6
+      10  11.2     75   19.9
+      # i 21 more rows
+    Code
+      print(tbl, known_arg = FALSE)
+    Output
+      # A data frame: 31 x 3
+         Girth Height Volume
+         <dbl>  <dbl>  <dbl>
+       1   8.3     70   10.3
+       2   8.6     65   10.3
+       3   8.8     63   10.2
+       4  10.5     72   16.4
+       5  10.7     81   18.8
+       6  10.8     83   19.7
+       7  11       66   15.6
+       8  11       75   18.2
+       9  11.1     80   22.6
+      10  11.2     75   19.9
+      # i 21 more rows
+

--- a/tests/testthat/test-tbl-format.R
+++ b/tests/testthat/test-tbl-format.R
@@ -80,9 +80,9 @@ test_that("get_width_print()", {
   expect_equal(get_width_print(140), 140)
 })
 
-test_that("format() signals an error if not all arguments in `...`are used", {
-    tbl <- new_tbl(trees)
-    expect_error(
-      format(tbl, unknown_arg = TRUE)
-    )
+test_that("format() signals an error if not all arguments in `...` are used", {
+  tbl <- new_tbl(trees)
+  expect_error(
+    format(tbl, unknown_arg = TRUE)
+  )
 })

--- a/tests/testthat/test-tbl-format.R
+++ b/tests/testthat/test-tbl-format.R
@@ -86,3 +86,23 @@ test_that("format() signals an error if not all arguments in `...` are used", {
     format(tbl, unknown_arg = TRUE)
   )
 })
+
+test_that("print() and format() can pass down arguments in `...`", {
+  local_methods(
+    tbl_format_setup.my_tibble = function(x, ..., known_arg = TRUE) {
+      setup <- NextMethod()
+      if (known_arg) {
+        setup$tbl_sum <- c(setup$tbl_sum, "Attribute" = "Set")
+      }
+      setup
+    }
+  )
+
+  tbl <- new_tbl(trees, class = "my_tibble")
+
+  expect_snapshot({
+    format(tbl, known_arg = TRUE)
+    print(tbl, known_arg = TRUE)
+    print(tbl, known_arg = FALSE)
+  })
+})

--- a/tests/testthat/test-tbl-format.R
+++ b/tests/testthat/test-tbl-format.R
@@ -79,26 +79,8 @@ test_that("get_width_print()", {
 })
 
 test_that("format() signals an error if not all arguments in `...`are used", {
-  my_env <- rlang::new_environment(
-    list(
-      tbl_format_setup.my_tibble = function(x, ..., known_arg = TRUE) {
-        setup <- NextMethod()
-        if (known_arg) {
-          setup$tbl_sum <- c(setup$tbl_sum, "Attribute" = "Set")
-        }
-        setup
-      }
-    )
-  )
-  withr::with_environment(my_env, {
-    tbl <- new_tbl(trees, class = "my_tibble")
-
-    expect_no_error(
-      format(tbl, known_arg = FALSE)
-    )
-
+    tbl <- new_tbl(trees)
     expect_error(
       format(tbl, unknown_arg = TRUE)
     )
-  })
 })

--- a/tests/testthat/test-tbl-format.R
+++ b/tests/testthat/test-tbl-format.R
@@ -77,3 +77,28 @@ test_that("get_width_print()", {
   expect_equal(get_width_print(80), 80)
   expect_equal(get_width_print(140), 140)
 })
+
+test_that("format() signals an error if not all arguments in `...`are used", {
+  my_env <- rlang::new_environment(
+    list(
+      tbl_format_setup.my_tibble = function(x, ..., known_arg = TRUE) {
+        setup <- NextMethod()
+        if (known_arg) {
+          setup$tbl_sum <- c(setup$tbl_sum, "Attribute" = "Set")
+        }
+        setup
+      }
+    )
+  )
+  withr::with_environment(my_env, {
+    tbl <- new_tbl(trees, class = "my_tibble")
+
+    expect_no_error(
+      format(tbl, known_arg = FALSE)
+    )
+
+    expect_error(
+      format(tbl, unknown_arg = TRUE)
+    )
+  })
+})


### PR DESCRIPTION
The use of `rlang::check_dots_empty` in `format_tbl` threw an error when arguments were passed via `...`. This behaviour seems unintended, as we deliberately pass `...` down to `tbl_format_setup`.

In this fix, we replace `rlang::check_dots_empty` with `rlang::check_dots_used` to ensure that all arguments passed to `format` (or `print`, for that matter) are utilized. This change prevents dangling arguments while allowing authors to add new arguments to their print functions.

A dedicated test case was added to `test-tbl-format.R`. We used `withr::with_environment` to ensure that the temporary `tbl_format_setup.my_tibble` method can be properly dispatched.