### PR TITLE
feat: Add color to commas for `tibble::glimpse()`

### DIFF
--- a/R/glimpse.R
+++ b/R/glimpse.R
@@ -128,6 +128,10 @@ format_glimpse <- function(x, ...) {
 
 # A variant with collapse and without checks, for format_glimpse.list()
 format_glimpse_1 <- function(x, ...) {
+  paste0(format_glimpse_(x, ...), collapse = crayon_grey_0.6(", "))
+}
+
+format_glimpse_list <- function(x, ...) {
   collapse(format_glimpse_(x, ...))
 }
 
@@ -155,8 +159,7 @@ format_glimpse.list <- function(x, ..., .inner = FALSE) {
     return("list()")
   }
 
-  out <- map_chr(x, format_glimpse_1, .inner = TRUE)
-
+  out <- map_chr(x, format_glimpse_list, .inner = TRUE)
   # Surround vectors by <>
   # Only surround inner lists by []
   list <- map_lgl(x, is.list)

--- a/R/glimpse.R
+++ b/R/glimpse.R
@@ -127,9 +127,9 @@ format_glimpse <- function(x, ...) {
 }
 
 # A variant with collapse and without checks, for format_glimpse.list()
-format_glimpse_1 <- function(x, ...) {
-  if (!is_null(list2(...)[[".inner"]]) && list2(...)[[".inner"]]) {
-    collapse(format_glimpse_(x, ...))
+format_glimpse_1 <- function(x, ..., .inner = NULL) {
+  if (!is_null(.inner) && .inner) {
+    collapse(format_glimpse_(x, ..., .inner = .inner))
   } else {
     paste0(format_glimpse_(x, ...), collapse = crayon_grey_0.6(", "))
   }

--- a/R/glimpse.R
+++ b/R/glimpse.R
@@ -128,11 +128,11 @@ format_glimpse <- function(x, ...) {
 
 # A variant with collapse and without checks, for format_glimpse.list()
 format_glimpse_1 <- function(x, ...) {
-  paste0(format_glimpse_(x, ...), collapse = crayon_grey_0.6(", "))
-}
-
-format_glimpse_list <- function(x, ...) {
-  collapse(format_glimpse_(x, ...))
+  if (!is_null(list2(...)[[".inner"]]) && list2(...)[[".inner"]]) {
+    collapse(format_glimpse_(x, ...))
+  } else {
+    paste0(format_glimpse_(x, ...), collapse = crayon_grey_0.6(", "))
+  }
 }
 
 format_glimpse_ <- function(x, ...) {
@@ -159,7 +159,7 @@ format_glimpse.list <- function(x, ..., .inner = FALSE) {
     return("list()")
   }
 
-  out <- map_chr(x, format_glimpse_list, .inner = TRUE)
+  out <- map_chr(x, format_glimpse_1, .inner = TRUE)
   # Surround vectors by <>
   # Only surround inner lists by []
   list <- map_lgl(x, is.list)

--- a/tests/testthat/_snaps/glimpse.md
+++ b/tests/testthat/_snaps/glimpse.md
@@ -245,43 +245,40 @@
       format_glimpse_1(list(1:3, "a, b", NA))
     Output
       [1] "<1, 2, 3>\033[90m, \033[39m\"a, b\"\033[90m, \033[39m\033[31mNA\033[39m"
-
-# format_glimpse_list() handles nested lists without coloring internal commas
-
     Code
       # # Simple list elements
-      format_glimpse_list(1:3)
+      format_glimpse_1(1:3, .inner = TRUE)
     Output
       [1] "1, 2, 3"
     Code
-      format_glimpse_list(letters[1:3])
+      format_glimpse_1(letters[1:3], .inner = TRUE)
     Output
       [1] "\"a\", \"b\", \"c\""
     Code
       # # Nested lists
-      format_glimpse_list(list(1:3))
+      format_glimpse_1(list(1:3), .inner = TRUE)
     Output
       [1] "<1, 2, 3>"
     Code
-      format_glimpse_list(list(list(1:3), list(4:6)))
+      format_glimpse_1(list(list(1:3), list(4:6)), .inner = TRUE)
     Output
       [1] "[<1, 2, 3>], [<4, 5, 6>]"
     Code
       # # Mixed content
-      format_glimpse_list(list(1:3, "a,b,c"))
+      format_glimpse_1(list(1:3, "a,b,c"), .inner = TRUE)
     Output
       [1] "<1, 2, 3>, \"a,b,c\""
     Code
-      format_glimpse_list(list(list(1, 2, 3), letters[1:3]))
+      format_glimpse_1(list(list(1, 2, 3), letters[1:3]), .inner = TRUE)
     Output
       [1] "[1, 2, 3], <\"a\", \"b\", \"c\">"
     Code
       # # Empty and NULL
-      format_glimpse_list(list())
+      format_glimpse_1(list(), .inner = TRUE)
     Output
-      [1] "list()"
+      [1] ""
     Code
-      format_glimpse_list(NULL)
+      format_glimpse_1(NULL, .inner = TRUE)
     Output
       [1] "NULL"
 

--- a/tests/testthat/_snaps/glimpse.md
+++ b/tests/testthat/_snaps/glimpse.md
@@ -216,6 +216,75 @@
       $ cyl  <dbl> 6, 4, 8
       $ data <list> [<tbl[11 x 11]>], [<tbl[7 x 11]>], [<tbl[14 x 11]>]
 
+# format_glimpse_1() handles commas correctly
+
+    Code
+      # # Vector with commas
+      format_glimpse_1(1:3)
+    Output
+      [1] "1\033[90m, \033[39m2\033[90m, \033[39m3"
+    Code
+      format_glimpse_1(c("a", "b", "c"))
+    Output
+      [1] "\"a\"\033[90m, \033[39m\"b\"\033[90m, \033[39m\"c\""
+    Code
+      format_glimpse_1(c(1, NA, 3))
+    Output
+      [1] "1\033[90m, \033[39m\033[31mNA\033[39m\033[90m, \033[39m3"
+    Code
+      # # Empty and single-element vectors
+      format_glimpse_1(integer())
+    Output
+      [1] ""
+    Code
+      format_glimpse_1(1)
+    Output
+      [1] "1"
+    Code
+      # # Mixed content with commas
+      format_glimpse_1(list(1:3, "a, b", NA))
+    Output
+      [1] "<1, 2, 3>\033[90m, \033[39m\"a, b\"\033[90m, \033[39m\033[31mNA\033[39m"
+
+# format_glimpse_list() handles nested lists without coloring internal commas
+
+    Code
+      # # Simple list elements
+      format_glimpse_list(1:3)
+    Output
+      [1] "1, 2, 3"
+    Code
+      format_glimpse_list(letters[1:3])
+    Output
+      [1] "\"a\", \"b\", \"c\""
+    Code
+      # # Nested lists
+      format_glimpse_list(list(1:3))
+    Output
+      [1] "<1, 2, 3>"
+    Code
+      format_glimpse_list(list(list(1:3), list(4:6)))
+    Output
+      [1] "[<1, 2, 3>], [<4, 5, 6>]"
+    Code
+      # # Mixed content
+      format_glimpse_list(list(1:3, "a,b,c"))
+    Output
+      [1] "<1, 2, 3>, \"a,b,c\""
+    Code
+      format_glimpse_list(list(list(1, 2, 3), letters[1:3]))
+    Output
+      [1] "[1, 2, 3], <\"a\", \"b\", \"c\">"
+    Code
+      # # Empty and NULL
+      format_glimpse_list(list())
+    Output
+      [1] "list()"
+    Code
+      format_glimpse_list(NULL)
+    Output
+      [1] "NULL"
+
 # color test for missing values
 
     Code
@@ -261,27 +330,27 @@
     Output
       Rows: 3
       Columns: 9
-      $ a [3m[90m<dbl>[39m[23m 1.0, 2.5, [31mNA[39m
-      $ b [3m[90m<int>[39m[23m 1, 2, [31mNA[39m
-      $ c [3m[90m<lgl>[39m[23m TRUE, FALSE, [31mNA[39m
-      $ d [3m[90m<chr>[39m[23m "a", "b", [31mNA[39m
-      $ e [3m[90m<fct>[39m[23m a, b, [31mNA[39m
-      $ f [3m[90m<date>[39m[23m 2015-12-10, 2015-12-11, [31mNA[39m
-      $ g [3m[90m<dttm>[39m[23m 2015-12-09 10:51:35, 2015-12-09 10:51:36, [31mNA[39m
-      $ h [3m[90m<list>[39m[23m 1, 2, [31mNA[39m
-      $ i [3m[90m<list>[39m[23m [1, <2, 3>], [<4, 5, 6>], [[31mNA[39m]
+      $ a [3m[90m<dbl>[39m[23m 1.0[90m, [39m2.5[90m, [39m[31mNA[39m
+      $ b [3m[90m<int>[39m[23m 1[90m, [39m2[90m, [39m[31mNA[39m
+      $ c [3m[90m<lgl>[39m[23m TRUE[90m, [39mFALSE[90m, [39m[31mNA[39m
+      $ d [3m[90m<chr>[39m[23m "a"[90m, [39m"b"[90m, [39m[31mNA[39m
+      $ e [3m[90m<fct>[39m[23m a[90m, [39mb[90m, [39m[31mNA[39m
+      $ f [3m[90m<date>[39m[23m 2015-12-10[90m, [39m2015-12-11[90m, [39m[31mNA[39m
+      $ g [3m[90m<dttm>[39m[23m 2015-12-09 10:51:35[90m, [39m2015-12-09 10:51:36[90m, [39m[31mNA[39m
+      $ h [3m[90m<list>[39m[23m 1[90m, [39m2[90m, [39m[31mNA[39m
+      $ i [3m[90m<list>[39m[23m [1, <2, 3>][90m, [39m[<4, 5, 6>][90m, [39m[[31mNA[39m]
     Code
       glimpse(as.data.frame(df_all))
     Output
       Rows: 3
       Columns: 9
-      $ a [3m[90m<dbl>[39m[23m 1.0, 2.5, [31mNA[39m
-      $ b [3m[90m<int>[39m[23m 1, 2, [31mNA[39m
-      $ c [3m[90m<lgl>[39m[23m TRUE, FALSE, [31mNA[39m
-      $ d [3m[90m<chr>[39m[23m "a", "b", [31mNA[39m
-      $ e [3m[90m<fct>[39m[23m a, b, [31mNA[39m
-      $ f [3m[90m<date>[39m[23m 2015-12-10, 2015-12-11, [31mNA[39m
-      $ g [3m[90m<dttm>[39m[23m 2015-12-09 10:51:35, 2015-12-09 10:51:36, [31mNA[39m
-      $ h [3m[90m<list>[39m[23m 1, 2, [31mNA[39m
-      $ i [3m[90m<list>[39m[23m [1, <2, 3>], [<4, 5, 6>], [[31mNA[39m]
+      $ a [3m[90m<dbl>[39m[23m 1.0[90m, [39m2.5[90m, [39m[31mNA[39m
+      $ b [3m[90m<int>[39m[23m 1[90m, [39m2[90m, [39m[31mNA[39m
+      $ c [3m[90m<lgl>[39m[23m TRUE[90m, [39mFALSE[90m, [39m[31mNA[39m
+      $ d [3m[90m<chr>[39m[23m "a"[90m, [39m"b"[90m, [39m[31mNA[39m
+      $ e [3m[90m<fct>[39m[23m a[90m, [39mb[90m, [39m[31mNA[39m
+      $ f [3m[90m<date>[39m[23m 2015-12-10[90m, [39m2015-12-11[90m, [39m[31mNA[39m
+      $ g [3m[90m<dttm>[39m[23m 2015-12-09 10:51:35[90m, [39m2015-12-09 10:51:36[90m, [39m[31mNA[39m
+      $ h [3m[90m<list>[39m[23m 1[90m, [39m2[90m, [39m[31mNA[39m
+      $ i [3m[90m<list>[39m[23m [1, <2, 3>][90m, [39m[<4, 5, 6>][90m, [39m[[31mNA[39m]
 

--- a/tests/testthat/test-glimpse.R
+++ b/tests/testthat/test-glimpse.R
@@ -102,6 +102,47 @@ test_that("output test for glimpse()", {
   })
 })
 
+test_that("format_glimpse_1() handles commas correctly", {
+  local_colors()
+
+  expect_snapshot({
+    "# Vector with commas"
+    format_glimpse_1(1:3)
+    format_glimpse_1(c("a", "b", "c"))
+    format_glimpse_1(c(1, NA, 3))
+
+    "# Empty and single-element vectors"
+    format_glimpse_1(integer())
+    format_glimpse_1(1)
+
+    "# Mixed content with commas"
+    format_glimpse_1(list(1:3, "a, b", NA))
+  })
+})
+
+test_that("format_glimpse_list() handles nested lists without coloring internal commas", {
+  local_colors()
+
+  expect_snapshot({
+
+    "# Simple list elements"
+    format_glimpse_list(1:3)
+    format_glimpse_list(letters[1:3])
+
+    "# Nested lists"
+    format_glimpse_list(list(1:3))
+    format_glimpse_list(list(list(1:3), list(4:6)))
+
+    "# Mixed content"
+    format_glimpse_list(list(1:3, "a,b,c"))
+    format_glimpse_list(list(list(1,2,3), letters[1:3]))
+
+    "# Empty and NULL"
+    format_glimpse_list(list())
+    format_glimpse_list(NULL)
+  })
+})
+
 test_that("color test for missing values", {
   local_colors()
 

--- a/tests/testthat/test-glimpse.R
+++ b/tests/testthat/test-glimpse.R
@@ -117,28 +117,23 @@ test_that("format_glimpse_1() handles commas correctly", {
 
     "# Mixed content with commas"
     format_glimpse_1(list(1:3, "a, b", NA))
-  })
-})
 
-test_that("format_glimpse_list() handles nested lists without coloring internal commas", {
-  local_colors()
-
-  expect_snapshot({
+    # format_glimpse_1 with .inner = TRUE
     "# Simple list elements"
-    format_glimpse_list(1:3)
-    format_glimpse_list(letters[1:3])
+    format_glimpse_1(1:3, .inner = TRUE)
+    format_glimpse_1(letters[1:3], .inner = TRUE)
 
     "# Nested lists"
-    format_glimpse_list(list(1:3))
-    format_glimpse_list(list(list(1:3), list(4:6)))
+    format_glimpse_1(list(1:3), .inner = TRUE)
+    format_glimpse_1(list(list(1:3), list(4:6)), .inner = TRUE)
 
     "# Mixed content"
-    format_glimpse_list(list(1:3, "a,b,c"))
-    format_glimpse_list(list(list(1,2,3), letters[1:3]))
+    format_glimpse_1(list(1:3, "a,b,c"), .inner = TRUE)
+    format_glimpse_1(list(list(1,2,3), letters[1:3]), .inner = TRUE)
 
     "# Empty and NULL"
-    format_glimpse_list(list())
-    format_glimpse_list(NULL)
+    format_glimpse_1(list(), .inner = TRUE)
+    format_glimpse_1(NULL, .inner = TRUE)
   })
 })
 

--- a/tests/testthat/test-glimpse.R
+++ b/tests/testthat/test-glimpse.R
@@ -124,7 +124,6 @@ test_that("format_glimpse_list() handles nested lists without coloring internal 
   local_colors()
 
   expect_snapshot({
-
     "# Simple list elements"
     format_glimpse_list(1:3)
     format_glimpse_list(letters[1:3])


### PR DESCRIPTION
fixes #658 

This was already partly fixed in https://github.com/r-lib/pillar/pull/662/files but coloring commas was still outstanding.
This PR aims to do that.

When using glimpse on a tibble that contains list columns, only the "outer" commas are colored in grey.