### PR TITLE
fledge: CRAN pre-release v1.10.99.9900

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pillar
 Title: Coloured Formatting for Columns
-Version: 1.10.2.9003
+Version: 1.10.99.9900
 Authors@R: 
     c(person(given = "Kirill",
              family = "M\u00fcller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,29 +10,9 @@
 
 - Refactor and comment formatting routine (#786).
 
-## Continuous integration
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#751).
-
-- Correct installation of xml2 (#747).
-
-- Import from actions-sync, check carefully (#745).
-
-- Sync (#744).
-
 ## Testing
 
 - Fix dev ggplot2 compatibility.
-
-- Snapshot updates for R-CMD-check-base (null) (#742).
-
-- Snapshot updates for R-CMD-check-dev ({"package":"ggplot2"}) (#748).
-
-- Snapshot updates for rcc-smoke (null) (#743).
-
-## Uncategorized
-
-- Switching to development version.
 
 
 # pillar 1.10.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# pillar 1.10.2.9003
+# pillar 1.10.99.9900
 
 ## Bug fixes
 
@@ -9,16 +9,6 @@
 ## Chore
 
 - Refactor and comment formatting routine (#786).
-
-
-# pillar 1.10.2.9002
-
-## Testing
-
-- Fix dev ggplot2 compatibility.
-
-
-# pillar 1.10.2.9001
 
 ## Continuous integration
 
@@ -32,14 +22,15 @@
 
 ## Testing
 
+- Fix dev ggplot2 compatibility.
+
 - Snapshot updates for R-CMD-check-base (null) (#742).
 
 - Snapshot updates for R-CMD-check-dev ({"package":"ggplot2"}) (#748).
 
 - Snapshot updates for rcc-smoke (null) (#743).
 
-
-# pillar 1.10.2.9000
+## Uncategorized
 
 - Switching to development version.
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-pillar 1.10.2
+pillar 1.10.99.9900
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-07-04, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`