### PR TITLE
fledge: CRAN release v1.11.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pillar
 Title: Coloured Formatting for Columns
-Version: 1.11.0.9007
+Version: 1.11.1
 Authors@R: 
     c(person(given = "Kirill",
              family = "M\u00fcller",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,33 +2,9 @@
 
 # pillar 1.11.1
 
-## fledge
-
-- CRAN release v1.11.0 (#789).
-
 ## Features
 
 - `glimpse()` also works for stingy duckplyr data frames.
-
-## Chore
-
-- Auto-update from GitHub Actions (#803).
-
-- Auto-update from GitHub Actions (#799).
-
-- Auto-update from GitHub Actions (#790).
-
-## Continuous integration
-
-- Use reviewdog for external PRs (#801).
-
-- Cleanup and fix macOS (#796).
-
-- Format with air, check detritus, better handling of `extra-packages` (#794).
-
-## Uncategorized
-
-- Merge branch 'docs'.
 
 
 # pillar 1.11.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,61 +1,34 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# pillar 1.11.0.9007
+# pillar 1.11.1
+
+## fledge
+
+- CRAN release v1.11.0 (#789).
 
 ## Features
 
 - `glimpse()` also works for stingy duckplyr data frames.
 
-
-# pillar 1.11.0.9006
-
 ## Chore
 
 - Auto-update from GitHub Actions (#803).
 
+- Auto-update from GitHub Actions (#799).
 
-# pillar 1.11.0.9005
+- Auto-update from GitHub Actions (#790).
 
 ## Continuous integration
 
 - Use reviewdog for external PRs (#801).
 
-
-# pillar 1.11.0.9004
-
-## Chore
-
-- Auto-update from GitHub Actions (#799).
-
-
-# pillar 1.11.0.9003
-
-## Continuous integration
-
 - Cleanup and fix macOS (#796).
-
-
-# pillar 1.11.0.9002
-
-## Continuous integration
 
 - Format with air, check detritus, better handling of `extra-packages` (#794).
 
-
-# pillar 1.11.0.9001
+## Uncategorized
 
 - Merge branch 'docs'.
-
-
-# pillar 1.11.0.9000
-
-## Chore
-
-- Auto-update from GitHub Actions (#790).
-
-## fledge
-
-- CRAN release v1.11.0 (#789).
 
 
 # pillar 1.11.0

--- a/README.Rmd
+++ b/README.Rmd
@@ -50,7 +50,7 @@ local({
 
 <!-- badges: start -->
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
-[![R build status](https://github.com/r-lib/pillar/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/pillar/actions)
+[![R build status](https://github.com/r-lib/pillar/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/pillar/actions)
 [![Coverage status](https://codecov.io/gh/r-lib/pillar/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/pillar)
 [![CRAN status](https://www.r-pkg.org/badges/version/pillar)](https://cran.r-project.org/package=pillar)
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Lifecycle:
 stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 [![R build
-status](https://github.com/r-lib/pillar/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/pillar/actions)
+status](https://github.com/r-lib/pillar/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/pillar/actions)
 [![Coverage
 status](https://codecov.io/gh/r-lib/pillar/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/pillar)
 [![CRAN

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-pillar 1.11.0
+pillar 1.11.1
 
 ## Cran Repository Policy
 

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@
 
 <!-- badges: start -->
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
-[![R build status](https://github.com/r-lib/pillar/workflows/R-CMD-check/badge.svg)](https://github.com/r-lib/pillar/actions)
+[![R build status](https://github.com/r-lib/pillar/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/r-lib/pillar/actions)
 [![Coverage status](https://codecov.io/gh/r-lib/pillar/branch/main/graph/badge.svg)](https://app.codecov.io/gh/r-lib/pillar)
 [![CRAN status](https://www.r-pkg.org/badges/version/pillar)](https://cran.r-project.org/package=pillar)
 <!-- badges: end -->


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-09-16, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`