### PR TITLE
docs: Add "Supported By Posit" badge to pillar website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -4,65 +4,66 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="pillar.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 url: https://pillar.r-lib.org/
 
 reference:
-  - title: Formatting tables
-    desc: >
-      Override or extend these methods if you want to customize the appearance
-      of your tibble-like object.
-    contents:
-      - tbl_format_setup
-      - tbl_format_header
-      - tbl_format_body
-      - tbl_format_footer
-      - ctl_new_pillar
-      - ctl_new_pillar_list
-      - tbl_sum
-      - tbl_nrow
-      - glimpse
-      - format_glimpse
-  - title: Formatting pillars
-    desc: >
-      Functions and methods to implement pillar support for your data type.
-    contents:
-      - pillar
-      - new_pillar
-      - new_pillar_component
-      - pillar_shaft
-      - starts_with("new_pillar_shaft")
-      - type_sum
-      - format_type_sum
-  - title: Styling
-    desc: >
-      For consistent output.
-    contents:
-      - starts_with("style_")
-      - align
-      - get_extent
-      - new_ornament
-      - new_pillar_title
-      - new_pillar_type
-      - dim_desc
-  - title: Miscellaneous
-    contents:
-      - pillar_options
-      - pillar-package
+- title: Formatting tables
+  desc: >
+    Override or extend these methods if you want to customize the appearance
+    of your tibble-like object.
+  contents:
+  - tbl_format_setup
+  - tbl_format_header
+  - tbl_format_body
+  - tbl_format_footer
+  - ctl_new_pillar
+  - ctl_new_pillar_list
+  - tbl_sum
+  - tbl_nrow
+  - glimpse
+  - format_glimpse
+- title: Formatting pillars
+  desc: >
+    Functions and methods to implement pillar support for your data type.
+  contents:
+  - pillar
+  - new_pillar
+  - new_pillar_component
+  - pillar_shaft
+  - starts_with("new_pillar_shaft")
+  - type_sum
+  - format_type_sum
+- title: Styling
+  desc: >
+    For consistent output.
+  contents:
+  - starts_with("style_")
+  - align
+  - get_extent
+  - new_ornament
+  - new_pillar_title
+  - new_pillar_type
+  - dim_desc
+- title: Miscellaneous
+  contents:
+  - pillar_options
+  - pillar-package
 
 articles:
-  - title: Articles
-    navbar: ~
-    contents:
-    - extending
-    - printing
-    - debugme
+- title: Articles
+  navbar:
+  contents:
+  - extending
+  - printing
+  - debugme
 
-  - title: Moved elsewhere
-    contents:
-    - digits
-    - numbers
+- title: Moved elsewhere
+  contents:
+  - digits
+  - numbers
 
 navbar:
   structure:


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the pillar website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of pillar website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/pillar-1200.png)

At 992px browser width:

![Screenshot of pillar website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/pillar-992.png)

At 991px browser width:

![Screenshot of pillar website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/pillar-991.png)

