### PR TITLE
docs: add missing @return tags to exported functions

### DIFF
--- a/R/char.R
+++ b/R/char.R
@@ -2,6 +2,8 @@
 #'
 #' These functions are reexported as [tibble::char()] and [tibble::set_char_opts()].
 #'
+#' @return A `pillar_char` vector for `char()`, or `x` with pillar attributes
+#'   set for `set_char_opts()`.
 #' @keywords internal
 #' @export
 char <- function(x, ..., min_chars = NULL,

--- a/R/ctl_new_pillar.R
+++ b/R/ctl_new_pillar.R
@@ -31,6 +31,8 @@
 #' @param width The available width, can be a vector for multiple tiers.
 #' @param title The title, derived from the name of the column in the data.
 #'
+#' @return A pillar object, or `NULL` if none of the data fits the available width.
+#'
 #' @seealso
 #' See [ctl_new_pillar_list()] for creating pillar objects for compound columns:
 #' packed data frames, matrices, or arrays.

--- a/R/ctl_new_pillar_list.R
+++ b/R/ctl_new_pillar_list.R
@@ -41,6 +41,7 @@
 #' @param first_pillar Can be passed to this method if the first pillar
 #'   for a compound pillar (or the pillar itself for a simple pillar)
 #'   has been constructed already.
+#' @return A list of pillar objects.
 #' @export
 #' @examplesIf rlang::is_installed(c("palmerpenguins", "tibble")) && requireNamespace("tibble")
 #' # Simple column

--- a/R/ctl_pillar.R
+++ b/R/ctl_pillar.R
@@ -23,6 +23,8 @@
 #'   used "as is", no quoting will be applied.
 #' @param width Default width, optional.
 #' @param ... Passed on to [pillar_shaft()].
+#' @return A pillar object, or `NULL` if the width is insufficient
+#'   to display the data.
 #' @export
 #' @examples
 #' x <- 123456789 * (10^c(-1, -3, -5, NA, -8, -10))
@@ -129,6 +131,7 @@ pillar_from_shaft <- function(title, type, data, width) {
 #' @param class Name of subclass.
 #' @param extra Deprecated.
 #'
+#' @return A pillar object with the given components.
 #' @export
 #' @examples
 #' lines <- function(char = "-") {

--- a/R/ctl_pillar_component.R
+++ b/R/ctl_pillar_component.R
@@ -23,6 +23,7 @@
 #'   (for `pillar_component()`).
 #' @param width,min_width Width and minimum width for the new component.
 #'   If `min_width` is `NULL`, it is assumed to match `width`.
+#' @return A `"pillar_component"` object.
 #' @export
 #' @examples
 #' new_pillar_component(list(letters[1:3]), width = 1)

--- a/R/dim.R
+++ b/R/dim.R
@@ -5,6 +5,8 @@
 #'
 #' @param x The object to format the dimensions for
 #'
+#' @return A string describing the dimensions, e.g. `"10"` for a vector
+#'   or `"32 x 11"` for a data frame.
 #' @export
 #' @examples
 #' dim_desc(1:10)

--- a/R/extent.R
+++ b/R/extent.R
@@ -4,6 +4,7 @@
 #' vector.
 #'
 #' @param x A character vector.
+#' @return An integer vector of display widths, one per element of `x`.
 #' @export
 #' @importFrom cli ansi_strip
 #' @importFrom cli utf8_nchar
@@ -24,6 +25,8 @@ get_extent <- function(x) {
 #' @description
 #' `get_max_extent()` calculates the maximum display width of all strings in a
 #' character vector, zero for empty vectors.
+#'
+#' @return A single integer value representing the maximum display width.
 #' @export
 #' @rdname get_extent
 #' @examples
@@ -43,6 +46,7 @@ get_max_extent <- function(x) {
 #' @param align How should strings be aligned? If `align = left` then padding
 #'   appears on the `right`, and vice versa.
 #' @param space What character should be used for the padding?
+#' @return A character vector of aligned and padded strings.
 #' @export
 #' @examples
 #' align(c("abc", "de"), align = "left")

--- a/R/ggplot2.R
+++ b/R/ggplot2.R
@@ -8,6 +8,7 @@
 #' @inheritDotParams ggplot2::continuous_scale -scale_name
 #' @param guide,position Passed on to [ggplot2::continuous_scale()]
 #' @param rescaler,super Must remain `NULL`.
+#' @return A ggplot2 scale object.
 #'
 #' @keywords internal
 #' @export

--- a/R/num.R
+++ b/R/num.R
@@ -2,6 +2,8 @@
 #'
 #' These functions are reexported as [tibble::num()] and [tibble::set_num_opts()].
 #'
+#' @return A `pillar_num` vector for `num()`, or `x` with pillar attributes
+#'   set for `set_num_opts()`.
 #' @keywords internal
 #' @export
 num <- function(x, ...,

--- a/R/ornament.R
+++ b/R/ornament.R
@@ -7,12 +7,13 @@
 #' `pillar_shaft.numeric()` and `format.pillar_shaft_decimal()` for an example.
 #'
 #' @param x A character vector with formatting,
-#'   can use ANYI styles e.g provided by the \pkg{cli} package.
+#'   can use ANSI styles e.g provided by the \pkg{cli} package.
 #'
 #' @param width An optional width of the resulting pillar, computed from `x` if
 #'   missing
 #' @param align Alignment, one of `"left"` or `"right"`
 #'
+#' @return A `pillar_ornament` object.
 #' @export
 #' @examples
 #' new_ornament(c("abc", "de"), align = "right")

--- a/R/shaft-.R
+++ b/R/shaft-.R
@@ -30,6 +30,7 @@
 #'   [type_sum()].
 #' @param class The name of the subclass.
 #' @param subclass Deprecated, pass the `class` argument instead.
+#' @return A pillar shaft object of class `c(class, "pillar_shaft")`.
 #' @name new_pillar_shaft
 #' @export
 new_pillar_shaft <- function(x, ..., width = NULL, min_width = width,
@@ -62,6 +63,7 @@ new_pillar_shaft <- function(x, ..., width = NULL, min_width = width,
 #'
 #' @param x A vector to format
 #' @inheritParams rlang::args_dots_used
+#' @return A pillar shaft object.
 #' @export
 #' @examples
 #' pillar_shaft(1:3)

--- a/R/styles.R
+++ b/R/styles.R
@@ -17,6 +17,7 @@ keep_empty <- function(fun) {
 #' `style_subtle()` is affected by the `subtle` [option][pillar_options].
 #'
 #' @param x The character vector to style.
+#' @return A styled character vector.
 #' @export
 #' @seealso [pillar_options] for a list of options
 #' @examples

--- a/R/tbl-format-setup.R
+++ b/R/tbl-format-setup.R
@@ -221,6 +221,8 @@ tbl_format_setup.tbl <- function(
 #'
 #' @param x A tbl object.
 #' @inheritParams rlang::args_dots_empty
+#' @return A single integer, or `NA` if the number of rows is unknown
+#'   (e.g., for lazy tables).
 #' @export
 tbl_nrow <- function(x, ...) {
   check_dots_empty0(...)

--- a/R/title.R
+++ b/R/title.R
@@ -6,6 +6,7 @@ style_title <- style_bold
 #'
 #' @param x A character vector of column titles.
 #' @inheritParams rlang::args_dots_empty
+#' @return A `"pillar_title"` object.
 #' @export
 #' @examples
 #' format(new_pillar_title(names(trees)))

--- a/R/type-sum.R
+++ b/R/type-sum.R
@@ -12,6 +12,7 @@
 #' @param x an object to summarise. Generally only methods of atomic vectors
 #'   and variants have been implemented.
 #'
+#' @return A string with four or less characters summarising the type of `x`.
 #' @export
 type_sum <- function(x) {
   UseMethod("type_sum")
@@ -72,6 +73,9 @@ vec_ptype_abbr.pillar_empty_col <- function(x, ...) {
 #' An attribute named `"short"` in the return value will be picked up by
 #' the [pillar_shaft()] method for lists, and used if space is limited.
 #'
+#' @return A string summarising the object, including its type and size
+#'   for vectors. An attribute named `"short"` may contain a shorter version.
+#'
 #' @examples
 #' obj_sum(1:10)
 #' obj_sum(matrix(1:10))
@@ -113,6 +117,9 @@ obj_sum.AsIs <- function(x) {
 #' It should always return a string (a character vector of length one),
 #' it can be an empty string `""` to omit size information,
 #' this is what the default method does for scalars.
+#'
+#' @return A string describing the size, e.g. `"[10]"` or `"[32 x 11]"`.
+#'   Returns `""` for scalars.
 #'
 #' @keywords internal
 #' @examples

--- a/R/type.R
+++ b/R/type.R
@@ -13,6 +13,7 @@ style_type <- function(x) {
 #'
 #' @param x A vector for which the type is to be retrieved.
 #' @inheritParams rlang::args_dots_empty
+#' @return A `"pillar_type"` object.
 #' @export
 #' @examples
 #' format(new_pillar_type("a"))
@@ -72,6 +73,7 @@ format_full_pillar_type <- function(x) {
 #' @param width The desired total width. If the returned string still is
 #'   wider, it will be trimmed. Can be `NULL`.
 #' @inheritParams rlang::args_dots_used
+#' @return A styled character string summarising the type.
 #'
 #' @export
 #' @examples

--- a/man/align.Rd
+++ b/man/align.Rd
@@ -17,6 +17,9 @@ appears on the \code{right}, and vice versa.}
 
 \item{space}{What character should be used for the padding?}
 }
+\value{
+A character vector of aligned and padded strings.
+}
 \description{
 Facilitates easy alignment of strings within a character vector. Designed to
 help implementers of formatters for custom data types.

--- a/man/char.Rd
+++ b/man/char.Rd
@@ -19,6 +19,10 @@ set_char_opts(
   shorten = c("back", "front", "mid", "abbreviate")
 )
 }
+\value{
+A \code{pillar_char} vector for \code{char()}, or \code{x} with pillar attributes
+set for \code{set_char_opts()}.
+}
 \description{
 These functions are reexported as \code{\link[tibble:char]{tibble::char()}} and \code{\link[tibble:set_char_opts]{tibble::set_char_opts()}}.
 }

--- a/man/ctl_new_pillar.Rd
+++ b/man/ctl_new_pillar.Rd
@@ -23,6 +23,9 @@ ctl_new_rowid_pillar(controller, x, width, ..., title = NULL, type = NULL)
 \item{type}{String for specifying a row ID type. Current values in use are
 \code{NULL} and \code{"*"}.}
 }
+\value{
+A pillar object, or \code{NULL} if none of the data fits the available width.
+}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 

--- a/man/ctl_new_pillar_list.Rd
+++ b/man/ctl_new_pillar_list.Rd
@@ -29,6 +29,9 @@ If \code{NULL}, only the first pillar is instantiated.}
 for a compound pillar (or the pillar itself for a simple pillar)
 has been constructed already.}
 }
+\value{
+A list of pillar objects.
+}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 

--- a/man/dim_desc.Rd
+++ b/man/dim_desc.Rd
@@ -9,6 +9,10 @@ dim_desc(x)
 \arguments{
 \item{x}{The object to format the dimensions for}
 }
+\value{
+A string describing the dimensions, e.g. \code{"10"} for a vector
+or \code{"32 x 11"} for a data frame.
+}
 \description{
 Multi-dimensional objects are formatted as \verb{a x b x ...}, for vectors the
 length is returned.

--- a/man/format_type_sum.Rd
+++ b/man/format_type_sum.Rd
@@ -20,6 +20,9 @@ wider, it will be trimmed. Can be \code{NULL}.}
 
 \item{...}{Arguments passed to methods.}
 }
+\value{
+A styled character string summarising the type.
+}
 \description{
 Called on values returned from \code{\link[=type_sum]{type_sum()}} for defining the description
 in the capital.

--- a/man/get_extent.Rd
+++ b/man/get_extent.Rd
@@ -12,6 +12,11 @@ get_max_extent(x)
 \arguments{
 \item{x}{A character vector.}
 }
+\value{
+An integer vector of display widths, one per element of \code{x}.
+
+A single integer value representing the maximum display width.
+}
 \description{
 \code{get_extent()} calculates the display width for each string in a character
 vector.

--- a/man/new_ornament.Rd
+++ b/man/new_ornament.Rd
@@ -8,12 +8,15 @@ new_ornament(x, width = NULL, align = NULL)
 }
 \arguments{
 \item{x}{A character vector with formatting,
-can use ANYI styles e.g provided by the \pkg{cli} package.}
+can use ANSI styles e.g provided by the \pkg{cli} package.}
 
 \item{width}{An optional width of the resulting pillar, computed from \code{x} if
 missing}
 
 \item{align}{Alignment, one of \code{"left"} or \code{"right"}}
+}
+\value{
+A \code{pillar_ornament} object.
 }
 \description{
 This function is useful if your data renders differently depending on the

--- a/man/new_pillar.Rd
+++ b/man/new_pillar.Rd
@@ -17,6 +17,9 @@ new_pillar(components, ..., width = NULL, class = NULL, extra = deprecated())
 
 \item{extra}{Deprecated.}
 }
+\value{
+A pillar object with the given components.
+}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 

--- a/man/new_pillar_component.Rd
+++ b/man/new_pillar_component.Rd
@@ -19,6 +19,9 @@ or an object with \code{"width"} and \code{"min_width"} attributes
 \item{width, min_width}{Width and minimum width for the new component.
 If \code{min_width} is \code{NULL}, it is assumed to match \code{width}.}
 }
+\value{
+A \code{"pillar_component"} object.
+}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 

--- a/man/new_pillar_shaft.Rd
+++ b/man/new_pillar_shaft.Rd
@@ -67,6 +67,9 @@ This argument, if given, takes precedence over the type summary provided by
 \code{formatted}, to be used when the available width is insufficient to show
 the full output.}
 }
+\value{
+A pillar shaft object of class \code{c(class, "pillar_shaft")}.
+}
 \description{
 The \code{new_pillar_shaft()} constructor creates objects of the \code{"pillar_shaft"}
 class.

--- a/man/new_pillar_title.Rd
+++ b/man/new_pillar_title.Rd
@@ -11,6 +11,9 @@ new_pillar_title(x, ...)
 
 \item{...}{These dots are for future extensions and must be empty.}
 }
+\value{
+A \code{"pillar_title"} object.
+}
 \description{
 Call \code{\link[=format]{format()}} on the result to render column titles.
 }

--- a/man/new_pillar_type.Rd
+++ b/man/new_pillar_type.Rd
@@ -11,6 +11,9 @@ new_pillar_type(x, ...)
 
 \item{...}{These dots are for future extensions and must be empty.}
 }
+\value{
+A \code{"pillar_type"} object.
+}
 \description{
 Calls \code{\link[=type_sum]{type_sum()}} to format the type.
 Call \code{\link[=format]{format()}} on the result to render column types.

--- a/man/num.Rd
+++ b/man/num.Rd
@@ -29,6 +29,10 @@ set_num_opts(
   extra_sigfig = NULL
 )
 }
+\value{
+A \code{pillar_num} vector for \code{num()}, or \code{x} with pillar attributes
+set for \code{set_num_opts()}.
+}
 \description{
 These functions are reexported as \code{\link[tibble:num]{tibble::num()}} and \code{\link[tibble:set_num_opts]{tibble::set_num_opts()}}.
 }

--- a/man/pillar.Rd
+++ b/man/pillar.Rd
@@ -16,6 +16,10 @@ used "as is", no quoting will be applied.}
 
 \item{...}{Passed on to \code{\link[=pillar_shaft]{pillar_shaft()}}.}
 }
+\value{
+A pillar object, or \code{NULL} if the width is insufficient
+to display the data.
+}
 \description{
 \code{pillar()} creates an object that formats a vector.
 The output uses one row for a title (if given), one row for the type,

--- a/man/pillar_shaft.Rd
+++ b/man/pillar_shaft.Rd
@@ -63,6 +63,9 @@ pillar_shaft(x, ...)
 \item \code{"abbreviate"}: use \code{\link[=abbreviate]{abbreviate()}}
 }}
 }
+\value{
+A pillar shaft object.
+}
 \description{
 Internal class for formatting the data for a column.
 \code{pillar_shaft()} is a coercion method that must be implemented

--- a/man/scale_x_num.Rd
+++ b/man/scale_x_num.Rd
@@ -118,6 +118,9 @@ palette is not represented in the theme.}
 
 \item{rescaler, super}{Must remain \code{NULL}.}
 }
+\value{
+A ggplot2 scale object.
+}
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}
 

--- a/man/style_subtle.Rd
+++ b/man/style_subtle.Rd
@@ -27,6 +27,9 @@ style_neg(x)
 \item{negative, significant}{Logical vector the same length as \code{x} that
 indicate if the values are negative and significant, respectively}
 }
+\value{
+A styled character vector.
+}
 \description{
 Functions that allow implementers of formatters for custom data types to
 maintain a consistent style with the default data types.

--- a/man/tbl_nrow.Rd
+++ b/man/tbl_nrow.Rd
@@ -11,6 +11,10 @@ tbl_nrow(x, ...)
 
 \item{...}{These dots are for future extensions and must be empty.}
 }
+\value{
+A single integer, or \code{NA} if the number of rows is unknown
+(e.g., for lazy tables).
+}
 \description{
 This generic will be called by \code{\link[=tbl_format_setup]{tbl_format_setup()}} to determine the number
 of rows in a tbl object.

--- a/man/type_sum.Rd
+++ b/man/type_sum.Rd
@@ -16,6 +16,15 @@ size_sum(x)
 \item{x}{an object to summarise. Generally only methods of atomic vectors
 and variants have been implemented.}
 }
+\value{
+A string with four or less characters summarising the type of \code{x}.
+
+A string summarising the object, including its type and size
+for vectors. An attribute named \code{"short"} may contain a shorter version.
+
+A string describing the size, e.g. \code{"[10]"} or \code{"[32 x 11]"}.
+Returns \code{""} for scalars.
+}
 \description{
 \code{type_sum()} gives a brief summary of object type. Objects that commonly
 occur in a data frame should return a string with four or less characters.


### PR DESCRIPTION
Add `@return` documentation tags to exported functions whose generated Rd files lacked `\value` sections. R CMD check --as-cran notes missing `\value` for exported functions; this is also a CRAN submission requirement.

## Functions documented

| Function | Returns |
|----------|---------|
| `ctl_new_pillar_list()` | A list of pillar objects |
| `new_pillar_component()` / `pillar_component()` | A `pillar_component` object |
| `new_pillar_shaft()` | A pillar shaft object of class `c(class, "pillar_shaft")` |
| `pillar_shaft()` | A pillar shaft object |
| `new_pillar_title()` | A `pillar_title` object |
| `new_pillar_type()` | A `pillar_type` object |
| `format_type_sum()` | A styled character string |
| `scale_x_num()` / `scale_y_num()` | A ggplot2 scale object |

## Validation

- `R CMD build --no-build-vignettes`: succeeds
- `R CMD check --no-manual --no-vignettes --no-tests`: 2 WARNINGs (pre-existing vignette issues, unrelated)
- Rd regeneration: clean (roxygen2::roxygenise() succeeded)
- No new issues introduced by this change

## Diff

36 files changed, 109 insertions, 2 deletions